### PR TITLE
Adding support for deep queries.

### DIFF
--- a/Source/ElasticLINQ.Test/Mapping/ElasticFieldsMappingWrapperTests.cs
+++ b/Source/ElasticLINQ.Test/Mapping/ElasticFieldsMappingWrapperTests.cs
@@ -1,11 +1,10 @@
 ﻿// Licensed under the Apache 2.0 License. See LICENSE.txt in the project root for more information.
 
 using ElasticLinq.Mapping;
-using ElasticLinq.Response.Model;
-using ElasticLinq.Test.TestSupport;
 using NSubstitute;
 using System;
-using System.Reflection;
+using System.Linq;
+using System.Linq.Expressions;
 using Xunit;
 using Xunit.Extensions;
 
@@ -57,11 +56,12 @@ namespace ElasticLinq.Test.Mapping
             var innerMapping = Substitute.For<IElasticMapping>();
             var mapping = new ElasticFieldsMappingWrapper(innerMapping);
             var member = typeof(ElasticFields).GetProperty(propertyName);
+            var memberExpression = Expression.MakeMemberAccess(null, member);
 
-            var result = mapping.GetFieldName("a.b.c", member);
+            var result = mapping.GetFieldName("a.b.c", memberExpression);
 
             Assert.Equal(expectedValue, result);
-            innerMapping.Received(0).GetFieldName("a.b.c", member);
+            innerMapping.Received(0).GetFieldName("a.b.c", memberExpression);
         }
 
         [Fact]
@@ -70,10 +70,12 @@ namespace ElasticLinq.Test.Mapping
             var innerMapping = Substitute.For<IElasticMapping>();
             var mapping = new ElasticFieldsMappingWrapper(innerMapping);
             var member = typeof(string).GetProperty("Length");
+            var constantExpression = Expression.Constant("string value");
+            var memberExpression = Expression.MakeMemberAccess(constantExpression, member);
 
-            mapping.GetFieldName("a.b.c", member);
+            mapping.GetFieldName("a.b.c", memberExpression);
 
-            innerMapping.Received(1).GetFieldName("a.b.c", member);
+            innerMapping.Received(1).GetFieldName("a.b.c", memberExpression);
         }
 
         [Fact]

--- a/Source/ElasticLINQ.Test/Mapping/ElasticMappingTests.cs
+++ b/Source/ElasticLINQ.Test/Mapping/ElasticMappingTests.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 using Xunit.Extensions;
@@ -87,7 +88,8 @@ namespace ElasticLinq.Test.Mapping
         {
             var mapping = new ElasticMapping();
 
-            Assert.Throws<ArgumentNullException>(() => mapping.GetFieldName("", null));
+            Assert.Throws<ArgumentNullException>(() => mapping.GetFieldName("", (MemberExpression)null));
+            Assert.Throws<ArgumentNullException>(() => mapping.GetFieldName("", (MemberInfo)null));
         }
 
         private class SingularTypeName { }

--- a/Source/ElasticLINQ.Test/Request/Visitors/ElasticQueryTranslation/ElasticQueryTranslationTestsBase.cs
+++ b/Source/ElasticLINQ.Test/Request/Visitors/ElasticQueryTranslation/ElasticQueryTranslationTestsBase.cs
@@ -31,6 +31,17 @@ namespace ElasticLinq.Test.Request.Visitors.ElasticQueryTranslation
             public double EnergyUse { get; set; }
             public int? Zone { get; set; }
             public List<string> Aliases { get; set; }
+            public RobotStats Stats { get; set; }
+        }
+
+        protected class RobotStats
+        {
+            public RobotLimbs Limbs { get; set; }
+        }
+
+        public class RobotLimbs
+        {
+            public Int32 HandCount { get; set; }
         }
     }
 }

--- a/Source/ElasticLINQ.Test/Request/Visitors/ElasticQueryTranslation/ElasticQueryTranslationWhereTests.cs
+++ b/Source/ElasticLINQ.Test/Request/Visitors/ElasticQueryTranslation/ElasticQueryTranslationWhereTests.cs
@@ -769,6 +769,18 @@ namespace ElasticLinq.Test.Request.Visitors.ElasticQueryTranslation
         }
 
         [Fact]
+        public static void SupportsDeepQueries()
+        {
+            const Int32 expectedConstant = 2;
+            var where = Robots.Where(e => e.Stats.Limbs.HandCount == expectedConstant);
+            var criteria = ElasticQueryTranslator.Translate(Mapping, "prefix", where.Expression).SearchRequest.Filter;
+
+            var termCriteria = Assert.IsType<TermCriteria>(criteria);
+            Assert.Equal("prefix.stats.limbs.handCount", termCriteria.Field);
+            Assert.Equal(expectedConstant, termCriteria.Value);
+        }
+
+        [Fact]
         public void RegexElasticMethodCreatesRegexWhereCriteria()
         {
             var where = Robots.Where(r => ElasticMethods.Regexp(r.Name, "r.*bot"));

--- a/Source/ElasticLINQ/Mapping/CouchbaseElasticMapping.cs
+++ b/Source/ElasticLINQ/Mapping/CouchbaseElasticMapping.cs
@@ -13,7 +13,7 @@ namespace ElasticLinq.Mapping
         /// <summary>
         /// Initializes a new instance of the <see cref="CouchbaseElasticMapping"/> class.
         /// </summary>
-        /// <param name="camelCaseFieldNames">Pass <c>true</c> to automatically camel-case field names (for <see cref="ElasticMapping.GetFieldName"/>).</param>
+        /// <param name="camelCaseFieldNames">Pass <c>true</c> to automatically camel-case field names (for <see cref="ElasticMapping.GetFieldName(string, System.Reflection.MemberInfo)"/>).</param>
         /// <param name="lowerCaseAnalyzedFieldValues">Pass <c>true</c> to automatically convert field values to lower case (for <see cref="ElasticMapping.FormatValue"/>).</param>
         /// <param name="conversionCulture">The culture to use for the lower-casing, camel-casing, and pluralization operations. If <c>null</c>,
         /// uses <see cref="CultureInfo.CurrentCulture"/>.</param>

--- a/Source/ElasticLINQ/Mapping/ElasticFieldsMappingWrapper.cs
+++ b/Source/ElasticLINQ/Mapping/ElasticFieldsMappingWrapper.cs
@@ -3,6 +3,7 @@
 using ElasticLinq.Request.Criteria;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace ElasticLinq.Mapping
@@ -40,12 +41,12 @@ namespace ElasticLinq.Mapping
         }
 
         /// <inheritdoc/>
-        public string GetFieldName(string prefix, MemberInfo memberInfo)
+        public string GetFieldName(string prefix, MemberExpression memberExpression)
         {
             return
-                memberInfo.DeclaringType == typeof(ElasticFields)
-                    ? "_" + memberInfo.Name.ToLowerInvariant()
-                    : wrapped.GetFieldName(prefix, memberInfo);
+                memberExpression.Member.DeclaringType == typeof(ElasticFields)
+                    ? "_" + memberExpression.Member.Name.ToLowerInvariant()
+                    : wrapped.GetFieldName(prefix, memberExpression);
         }
 
         /// <inheritdoc/>

--- a/Source/ElasticLINQ/Mapping/IElasticMapping.cs
+++ b/Source/ElasticLINQ/Mapping/IElasticMapping.cs
@@ -3,6 +3,7 @@
 using ElasticLinq.Request.Criteria;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace ElasticLinq.Mapping
@@ -53,9 +54,9 @@ namespace ElasticLinq.Mapping
         /// </summary>
         /// <param name="prefix">The prefix to put in front of this field name, if the field is
         /// an ongoing part of the document search.</param>
-        /// <param name="memberInfo">The member whose name is required.</param>
+        /// <param name="memberExpression">The member whose name is required.</param>
         /// <returns>Returns the ElasticSearch field name that matches the member.</returns>
-        string GetFieldName(string prefix, MemberInfo memberInfo);
+        string GetFieldName(string prefix, MemberExpression memberExpression);
 
         /// <summary>
         /// Gets criteria that can be used to find documents of a particular type. Will be used by

--- a/Source/ElasticLINQ/Request/Visitors/FacetExpressionVisitor.cs
+++ b/Source/ElasticLINQ/Request/Visitors/FacetExpressionVisitor.cs
@@ -38,7 +38,7 @@ namespace ElasticLinq.Request.Visitors
         };
 
         private bool aggregateWithoutMember;
-        private readonly HashSet<MemberInfo> aggregateMembers = new HashSet<MemberInfo>();
+        private readonly HashSet<MemberExpression> aggregateMembers = new HashSet<MemberExpression>();
         private readonly Dictionary<string, ICriteria> aggregateCriteria = new Dictionary<string, ICriteria>();
         private readonly ParameterExpression bindingParameter = Expression.Parameter(typeof(AggregateRow), "r");
 
@@ -72,7 +72,7 @@ namespace ElasticLinq.Request.Visitors
             {
                 case ExpressionType.MemberAccess:
                     {
-                        var groupByField = Mapping.GetFieldName(Prefix, ((MemberExpression)groupBy).Member);
+                        var groupByField = Mapping.GetFieldName(Prefix, (MemberExpression)groupBy);
                         if (aggregateWithoutMember)
                             yield return new TermsFacet(GroupKeyFacet, null, size, groupByField);
 
@@ -146,7 +146,7 @@ namespace ElasticLinq.Request.Visitors
                 if (aggregateMemberOperations.TryGetValue(m.Method.Name, out operation) && m.Arguments.Count == 2)
                     return VisitAggregateMemberOperation(m.Arguments[1], operation, m.Method.ReturnType);
             }
-            
+
             return m; // Do not base.VisitMethodCall as we don't want to examine the whole tree
         }
 
@@ -189,7 +189,7 @@ namespace ElasticLinq.Request.Visitors
 
         private Expression VisitAggregateMemberOperation(Expression property, string operation, Type returnType)
         {
-            var member = GetMemberInfoFromLambda(property);
+            var member = GetMemberExpressionFromLambda(property);
             aggregateMembers.Add(member);
             return RebindValue(Mapping.GetFieldName(Prefix, member), operation, returnType);
         }
@@ -201,7 +201,7 @@ namespace ElasticLinq.Request.Visitors
             return Expression.Convert(getValueExpression, returnType);
         }
 
-        private static MemberInfo GetMemberInfoFromLambda(Expression expression)
+        private static MemberExpression GetMemberExpressionFromLambda(Expression expression)
         {
             var lambda = expression.StripQuotes() as LambdaExpression;
             if (lambda == null)
@@ -211,7 +211,7 @@ namespace ElasticLinq.Request.Visitors
             if (memberExpressionBody == null)
                 throw new NotSupportedException(String.Format("Aggregates must be specified against a member of the entity not {0}", lambda.Body.Type));
 
-            return memberExpressionBody.Member;
+            return memberExpressionBody;
         }
     }
 }

--- a/Source/ElasticLINQ/Request/Visitors/MemberProjectionExpressionVisitor.cs
+++ b/Source/ElasticLINQ/Request/Visitors/MemberProjectionExpressionVisitor.cs
@@ -53,7 +53,7 @@ namespace ElasticLinq.Request.Visitors
 
         private Expression VisitFieldSelection(MemberExpression m)
         {
-            var fieldName = Mapping.GetFieldName(Prefix, m.Member);
+            var fieldName = Mapping.GetFieldName(Prefix, m);
             fieldNames.Add(fieldName);
             var getFieldExpression = Expression.Call(null, GetDictionaryValueMethod, Expression.PropertyOrField(BindingParameter, "fields"), Expression.Constant(fieldName), Expression.Constant(m.Type));
             return Expression.Convert(getFieldExpression, m.Type);


### PR DESCRIPTION
This version changes `IElasticMapping` to take `MemberExpression` instead of `MemberInfo`.

There are two issues here:
- There are 2 failing facets tests (which probably means I broke facets). Damien will need to look at that to understand how much of an idiot I am.
- There is only the single test for deep property accessors. That needs to be moved to the right place and/or expanded to support all expression types (not just equals), since in theory deep property accessors are valid everywhere. :)
