### PR TITLE
Count support

### DIFF
--- a/Source/ElasticLINQ.Test/ElasticLINQ.Test.csproj
+++ b/Source/ElasticLINQ.Test/ElasticLINQ.Test.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Request\Visitors\PartialEvaluatorTests.cs" />
     <Compile Include="Request\Visitors\MemberProjectionExpressionVisitorTests.cs" />
     <Compile Include="Response\Materializers\AggregatesTests.cs" />
+    <Compile Include="Response\Materializers\CountElasticMaterializerTests.cs" />
     <Compile Include="Response\Materializers\ManyFacetsElasticMaterializerTests.cs" />
     <Compile Include="Response\Materializers\MaterializerTestHelper.cs" />
     <Compile Include="Response\Materializers\OneHitElasticMaterializerTests.cs" />

--- a/Source/ElasticLINQ.Test/Request/Visitors/ElasticQueryTranslation/ElasticQueryTranslationSingularTests.cs
+++ b/Source/ElasticLINQ.Test/Request/Visitors/ElasticQueryTranslation/ElasticQueryTranslationSingularTests.cs
@@ -135,7 +135,7 @@ namespace ElasticLinq.Test.Request.Visitors.ElasticQueryTranslation
 
 
         [Fact]
-        public void CountTranslatesToFilter()
+        public void CountTranslatesToSizeOfZeroFilter()
         {
             var first = MakeQueryableExpression("Count", Robots);
 
@@ -143,6 +143,21 @@ namespace ElasticLinq.Test.Request.Visitors.ElasticQueryTranslation
 
             Assert.Equal(0, request.Size);
             Assert.IsType<ExistsCriteria>(request.Filter);
+        }
+
+        [Fact]
+        public void CountWithPredicateTranslatesToSizeOfZeroFilter()
+        {
+            const string expectedTermValue = "Josef";
+            Expression<Func<Robot, bool>> lambda = r => r.Name == expectedTermValue;
+            var first = MakeQueryableExpression("Count", Robots, lambda);
+
+            var request = ElasticQueryTranslator.Translate(Mapping, "prefix", first).SearchRequest;
+
+            Assert.Equal(0, request.Size);
+            var termCriteria = Assert.IsType<TermCriteria>(request.Filter);
+            Assert.Equal("prefix.name", termCriteria.Field);
+            Assert.Equal(expectedTermValue, termCriteria.Value);
         }
     }
 }

--- a/Source/ElasticLINQ.Test/Request/Visitors/ElasticQueryTranslation/ElasticQueryTranslationSingularTests.cs
+++ b/Source/ElasticLINQ.Test/Request/Visitors/ElasticQueryTranslation/ElasticQueryTranslationSingularTests.cs
@@ -132,5 +132,17 @@ namespace ElasticLinq.Test.Request.Visitors.ElasticQueryTranslation
                 .Single(a => a.GetParameters().Length == parameterCount)
                 .MakeGenericMethod(typeof(TSource));
         }
+
+
+        [Fact]
+        public void CountTranslatesToFilter()
+        {
+            var first = MakeQueryableExpression("Count", Robots);
+
+            var request = ElasticQueryTranslator.Translate(Mapping, "prefix", first).SearchRequest;
+
+            Assert.Equal(0, request.Size);
+            Assert.IsType<ExistsCriteria>(request.Filter);
+        }
     }
 }

--- a/Source/ElasticLINQ.Test/Response/Materializers/CountElasticMaterializerTests.cs
+++ b/Source/ElasticLINQ.Test/Response/Materializers/CountElasticMaterializerTests.cs
@@ -1,0 +1,20 @@
+﻿using ElasticLinq.Response.Materializers;
+using Xunit;
+
+namespace ElasticLinq.Test.Response.Materializers
+{
+    public class CountElasticMaterializerTests
+    {
+        [Fact]
+        public void FirstOrDefaultReturnsDefaultGivenNoResults()
+        {
+            const int expected = 5;
+            var response = MaterializerTestHelper.CreateSampleResponse(expected);
+            var materializer = new CountElasticMaterializer();
+
+            var actual = materializer.Materialize(response);
+
+            Assert.Equal(expected, actual);
+        }        
+    }
+}

--- a/Source/ElasticLINQ.Test/Response/Materializers/MaterializerTestHelper.cs
+++ b/Source/ElasticLINQ.Test/Response/Materializers/MaterializerTestHelper.cs
@@ -21,7 +21,7 @@ namespace ElasticLinq.Test.Response.Materializers
 
         internal static ElasticResponse CreateSampleResponse(int count)
         {
-            return new ElasticResponse { hits = new Hits { hits = CreateSampleHits(count) } };
+            return new ElasticResponse { hits = new Hits { hits = CreateSampleHits(count), total = count} };
         }
 
         public static Hit CreateHit(string sampleField)

--- a/Source/ElasticLINQ/ElasticLINQ.csproj
+++ b/Source/ElasticLINQ/ElasticLINQ.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Request\Visitors\FacetExpressionVisitor.cs" />
     <Compile Include="Request\Visitors\CriteriaExpressionVisitor.cs" />
     <Compile Include="Response\Materializers\Aggregates.cs" />
+    <Compile Include="Response\Materializers\CountElasticMaterializer.cs" />
     <Compile Include="Response\Materializers\ManyFacetsElasticMaterializer.cs" />
     <Compile Include="Request\Criteria\TermsCriteria.cs" />
     <Compile Include="Request\Criteria\TermsExecutionMode.cs" />

--- a/Source/ElasticLINQ/Request/Visitors/ElasticQueryTranslator.cs
+++ b/Source/ElasticLINQ/Request/Visitors/ElasticQueryTranslator.cs
@@ -174,10 +174,20 @@ namespace ElasticLinq.Request.Visitors
                     if (m.Arguments.Count == 2)
                         return VisitOrderBy(m.Arguments[0], m.Arguments[1], m.Method.Name == "ThenBy");
                     break;
+
+                case "Count":
+                    return VisitCount(m.Arguments[0]);
             }
 
             throw new NotSupportedException(string.Format("The Queryable method '{0}' is not supported", m.Method.Name));
         }
+
+        private Expression VisitCount(Expression expression)
+        {
+            materializer = new CountElasticMaterializer();
+            return Visit(expression);
+        }
+
 
         private Expression VisitFirstOrSingle(Expression source, Expression predicate, string methodName)
         {

--- a/Source/ElasticLINQ/Request/Visitors/ElasticQueryTranslator.cs
+++ b/Source/ElasticLINQ/Request/Visitors/ElasticQueryTranslator.cs
@@ -185,7 +185,7 @@ namespace ElasticLinq.Request.Visitors
         private Expression VisitCount(Expression expression)
         {
             materializer = new CountElasticMaterializer();
-            return Visit(expression);
+            return VisitTake(expression, Expression.Constant(0));
         }
 
 

--- a/Source/ElasticLINQ/Request/Visitors/ElasticQueryTranslator.cs
+++ b/Source/ElasticLINQ/Request/Visitors/ElasticQueryTranslator.cs
@@ -176,16 +176,19 @@ namespace ElasticLinq.Request.Visitors
                     break;
 
                 case "Count":
-                    return VisitCount(m.Arguments[0]);
+                    return VisitCount(m.Arguments[0], m.Arguments.Count == 2 ? m.Arguments[1] : null);
             }
 
             throw new NotSupportedException(string.Format("The Queryable method '{0}' is not supported", m.Method.Name));
         }
 
-        private Expression VisitCount(Expression expression)
+        private Expression VisitCount(Expression source, Expression predicate)
         {
             materializer = new CountElasticMaterializer();
-            return VisitTake(expression, Expression.Constant(0));
+            searchRequest.Size = 0;
+            return predicate != null 
+                ? VisitWhere(source, predicate) 
+                : Visit(source);
         }
 
 

--- a/Source/ElasticLINQ/Response/Materializers/CountElasticMaterializer.cs
+++ b/Source/ElasticLINQ/Response/Materializers/CountElasticMaterializer.cs
@@ -1,0 +1,15 @@
+﻿using ElasticLinq.Response.Model;
+
+namespace ElasticLinq.Response.Materializers
+{
+    /// <summary>
+    /// Materializes total count
+    /// </summary>
+    internal class CountElasticMaterializer : IElasticMaterializer
+    {
+        public object Materialize(ElasticResponse response)
+        {
+            return (int)response.hits.total;
+        }
+    }
+}


### PR DESCRIPTION
added support for `Count`
Example:

``` C#
var personCount = context.Query<Person>().Count();
```

i hope the test for the `ElasticQueryTranslator` is added to the correct file
