### PR TITLE
Updated ToCamelCase to better handle strings containing acronyms.

### DIFF
--- a/Source/ElasticLINQ.Test/Mapping/MappingHelpersTests.cs
+++ b/Source/ElasticLINQ.Test/Mapping/MappingHelpersTests.cs
@@ -14,11 +14,11 @@ namespace ElasticLinq.Test.Mapping
         private readonly static CultureInfo usCulture = new CultureInfo(0x0409);
 
         [Fact]
-        public static void ToCamelCaseWithAllCapsLowersFirstCapitalOnly()
+        public static void ToCamelCaseWithAllCapsLowersAllText()
         {
             var actual = "ALLCAPS".ToCamelCase(usCulture);
 
-            Assert.Equal("aLLCAPS", actual);
+            Assert.Equal("allcaps", actual);
         }
 
         [Fact]
@@ -27,6 +27,22 @@ namespace ElasticLinq.Test.Mapping
             var actual = "lowercase".ToCamelCase(usCulture);
 
             Assert.Equal("lowercase", actual);
+        }
+
+        [Fact]
+        public static void ToCamelCaseWithAcronymLowersAcronym()
+        {
+            var actual = "ACRONYMThenLowerCase".ToCamelCase(usCulture);
+
+            Assert.Equal("acronymThenLowerCase", actual);
+        }
+
+        [Fact]
+        public static void ToCamelCaseEndingWithAcronym()
+        {
+            var actual = "EndsWithACRONYM".ToCamelCase(usCulture);
+
+            Assert.Equal("endsWithACRONYM", actual);
         }
 
         [Fact]

--- a/Source/ElasticLINQ/Mapping/MappingHelpers.cs
+++ b/Source/ElasticLINQ/Mapping/MappingHelpers.cs
@@ -5,6 +5,7 @@ using System;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace ElasticLinq.Mapping
 {
@@ -14,18 +15,17 @@ namespace ElasticLinq.Mapping
     public static class MappingHelpers
     {
         /// <summary>
-        /// Convert a string to camel case by lower-casing just the first letter.
+        /// Convert a string to camel-case.
         /// </summary>
         /// <param name="value">Input string to be camel-cased.</param>
         /// <param name="culture">CultureInfo to be used to lower-case first character.</param>
-        /// <returns>String where first letter has been lower-cased.</returns>
+        /// <returns>String that has been converted to camel-case.</returns>
         public static string ToCamelCase(this string value, CultureInfo culture)
         {
             Argument.EnsureNotNull("value", value);
 
-            return value.Length < 2
-                ? culture.TextInfo.ToLower(value)
-                : culture.TextInfo.ToLower(value[0]) + value.Substring(1);
+            var words = Regex.Split(value, "(?<!(^|[A-Z]))(?=[A-Z])|(?<!^)(?=[A-Z][a-z])");
+            return string.Concat(words.First().ToLowerInvariant(), string.Concat(words.Skip(1)));
         }
 
         /// <summary>


### PR DESCRIPTION
This changes the behavior of ToCamelCase from a ToLower on the first character to a more robust word match, which should better match intent when converting strings containing acronyms (eg: "OSType"). 

Credit to http://stackoverflow.com/questions/7593969/regex-to-split-camelcase-or-titlecase-advanced for the regex used to match camel case.
