### PR TITLE
Add support for prefix of string collection fields

### DIFF
--- a/Source/ElasticLINQ.Test/ElasticMethodsTests.cs
+++ b/Source/ElasticLINQ.Test/ElasticMethodsTests.cs
@@ -31,6 +31,13 @@ namespace ElasticLinq.Test
         }
 
         [Fact]
+        public void PrefixArrayThrowsIfAccessed()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() => ElasticMethods.Prefix(new[] { "a1", "a2" }, "b"));
+            Assert.Contains("ElasticMethods.Prefix", ex.Message);
+        }
+
+        [Fact]
         public void RegexpThrowsIfAccessed()
         {
             var ex = Assert.Throws<InvalidOperationException>(() => ElasticMethods.Regexp("a", "b"));

--- a/Source/ElasticLINQ.Test/Request/Visitors/ElasticQueryTranslation/ElasticQueryTranslationNotSupportedTests.cs
+++ b/Source/ElasticLINQ.Test/Request/Visitors/ElasticQueryTranslation/ElasticQueryTranslationNotSupportedTests.cs
@@ -98,6 +98,27 @@ namespace ElasticLinq.Test.Request.Visitors.ElasticQueryTranslation
         }
 
         [Fact]
+        public static void PrefixArrayMustBeBetweenMemberAndConstant()
+        {
+            const string expectedMessageFragment = "Prefix must take a member";
+
+            {
+                var ex = Assert.Throws<NotSupportedException>(() => Translate(Robots.Where(r => ElasticMethods.Prefix(r.Aliases, r.Name))));
+                Assert.Contains(expectedMessageFragment, ex.Message);
+            }
+
+            {
+                var ex = Assert.Throws<NotSupportedException>(() => Translate(Robots.Where(r => ElasticMethods.Prefix(new[] { "", "a" }, r.Name))));
+                Assert.Contains(expectedMessageFragment, ex.Message);
+            }
+
+            {
+                var ex = Assert.Throws<NotSupportedException>(() => Translate(Robots.Where(r => ElasticMethods.Prefix(new[] { "", "a" }, ""))));
+                Assert.Contains(expectedMessageFragment, ex.Message);
+            }
+        }
+
+        [Fact]
         public static void RegexpMustBeBetweenMemberAndConstant()
         {
             const string expectedMessageFragment = "Regexp must take a member";

--- a/Source/ElasticLINQ.Test/Request/Visitors/ElasticQueryTranslation/ElasticQueryTranslationWhereTests.cs
+++ b/Source/ElasticLINQ.Test/Request/Visitors/ElasticQueryTranslation/ElasticQueryTranslationWhereTests.cs
@@ -915,6 +915,18 @@ namespace ElasticLinq.Test.Request.Visitors.ElasticQueryTranslation
         }
 
         [Fact]
+        public void PrefixArrayElasticMethodCreatesPrefixWhereCriteria()
+        {
+            var where = Robots.Where(r => ElasticMethods.Prefix(r.Aliases, "robot"));
+            var criteria = ElasticQueryTranslator.Translate(Mapping, where.Expression).SearchRequest.Filter;
+
+            var regexpCriteria = Assert.IsType<PrefixCriteria>(criteria);
+            Assert.Equal("prefix", regexpCriteria.Name);
+            Assert.Equal("aliases", regexpCriteria.Field);
+            Assert.Equal("robot", regexpCriteria.Prefix);
+        }
+
+        [Fact]
         public void ConvertIsOtherwiseIgnored()
         {
             var where = Robots.Where(r => ((double)r.Cost).Equals(1));

--- a/Source/ElasticLINQ/ElasticMethods.cs
+++ b/Source/ElasticLINQ/ElasticMethods.cs
@@ -47,12 +47,23 @@ namespace ElasticLinq
         }
 
         /// <summary>
-        /// Specifies a regular expression term query for a field.
+        /// Specifies a prefix term query for a field.
         /// </summary>
         /// <param name="field">Field name to be matched.</param>
         /// <param name="startsWith">String the field must start with to match.</param>
         /// <returns>true if the field starts with the startsWith; otherwise, false.</returns>
         public static bool Prefix(string field, string startsWith)
+        {
+            throw BuildException();
+        }
+
+        /// <summary>
+        /// Specifies a prefix term query for a field.
+        /// </summary>
+        /// <param name="field">Field name to be matched.</param>
+        /// <param name="startsWith">String the field must start with to match.</param>
+        /// <returns>true if the field starts with the startsWith; otherwise, false.</returns>
+        public static bool Prefix(IEnumerable<string> field, string startsWith)
         {
             throw BuildException();
         }


### PR DESCRIPTION
I know unit-tests are yet to be done on this change, but I'm raising this early so we can have discussion around this.

In elastic search world, you can use `prefix` for both `string` fields and `string[]` fields, but only the former is currently supported on elasticLINQ.

this PR is adding support for the latter and it's surprizingly simple! :)
basically the entire expression mapping just works fine.

Please let me know what you think.
