### PR TITLE
Connection abstraction

### DIFF
--- a/Source/ElasticLINQ.IntegrationTest/Data.cs
+++ b/Source/ElasticLINQ.IntegrationTest/Data.cs
@@ -38,7 +38,7 @@ namespace ElasticLINQ.IntegrationTest
                 throw new InvalidOperationException(
                     String.Format("Tests expect {0} entries but {1} loaded from Elasticsearch index '{2}' at {3}",
                         expectedDataCount, memory.Count,
-                        elasticContext.Connection.Index, elasticContext.Connection.Endpoint));
+						elasticContext.Connection.Index, ((ElasticConnection)elasticContext.Connection).Endpoint));
         }
     }
 }

--- a/Source/ElasticLINQ.Test/ElasticConnectionTests.cs
+++ b/Source/ElasticLINQ.Test/ElasticConnectionTests.cs
@@ -1,13 +1,25 @@
 ﻿// Licensed under the Apache 2.0 License. See LICENSE.txt in the project root for more information.
 
 using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using ElasticLinq.Logging;
+using ElasticLinq.Mapping;
+using ElasticLinq.Request;
+using ElasticLinq.Request.Formatters;
+using ElasticLinq.Test.Utility;
 using Xunit;
 
 namespace ElasticLinq.Test
 {
     public class ElasticConnectionTests
     {
+		private static readonly IElasticMapping mapping = new TrivialElasticMapping();
+		private static readonly ILog log = NullLog.Instance;
         private readonly Uri endpoint = new Uri("http://localhost:1234/abc");
         private const string Password = "thePassword";
         private const string UserName = "theUser";
@@ -115,6 +127,135 @@ namespace ElasticLinq.Test
             await Assert.ThrowsAsync<NullReferenceException>(() => connection.HttpClient.GetAsync(new Uri("http://something.com")));
             Assert.Equal(connection.Disposing, true);
         }
+
+		[Fact]
+		public static async Task NoAuthorizationWithEmptyUserName()
+		{
+			var messageHandler = new SpyMessageHandler();
+			var localConnection = new ElasticConnection(messageHandler, new Uri("http://localhost"));
+			var request = new SearchRequest { DocumentType = "docType" };
+			var formatter = new SearchRequestFormatter(localConnection, mapping, request);
+
+			await localConnection.Search(
+				localConnection.Index ?? "_all",
+				request.DocumentType,
+				formatter.Body,
+				request,
+				log);
+
+			Assert.Null(messageHandler.Request.Headers.Authorization);
+		}
+
+		[Fact]
+		public static async Task ForcesBasicAuthorizationWhenProvidedWithUsernameAndPassword()
+		{
+			var messageHandler = new SpyMessageHandler();
+			var localConnection = new ElasticConnection(messageHandler, new Uri("http://localhost"), "myUser", "myPass");
+			var request = new SearchRequest { DocumentType = "docType" };
+			var formatter = new SearchRequestFormatter(localConnection, mapping, request);
+
+			await localConnection.Search(
+				localConnection.Index ?? "_all",
+				request.DocumentType,
+				formatter.Body,
+				request,
+				log);
+
+			var auth = messageHandler.Request.Headers.Authorization;
+			Assert.NotNull(auth);
+			Assert.Equal("Basic", auth.Scheme);
+			Assert.Equal("myUser:myPass", Encoding.ASCII.GetString(Convert.FromBase64String(auth.Parameter)));
+		}
+
+		[Fact]
+		public static async void NonSuccessfulHttpRequestThrows()
+		{
+			var messageHandler = new SpyMessageHandler();
+			messageHandler.Response.StatusCode = HttpStatusCode.NotFound;
+			var localConnection = new ElasticConnection(messageHandler, new Uri("http://localhost"), "myUser", "myPass");
+			var request = new SearchRequest { DocumentType = "docType" };
+			var formatter = new SearchRequestFormatter(localConnection, mapping, request);
+
+			var ex = await Record.ExceptionAsync(() => localConnection.Search(
+				localConnection.Index ?? "_all",
+				request.DocumentType,
+				formatter.Body,
+				request,
+				log));
+
+			Assert.IsType<HttpRequestException>(ex);
+			Assert.Equal("Response status code does not indicate success: 404 (Not Found).", ex.Message);
+		}
+
+		[Fact]
+		public static async Task LogsDebugMessagesDuringExecution()
+		{
+			var responseString = BuildResponseString(2, 1, 1, 0.3141, "testIndex", "testType", "testId");
+			var messageHandler = new SpyMessageHandler();
+			var log = new SpyLog();
+			messageHandler.Response.Content = new StringContent(responseString);
+			var localConnection = new ElasticConnection(messageHandler, new Uri("http://localhost"), "myUser", "myPass", index: "SearchIndex");
+			var request = new SearchRequest { DocumentType = "abc123", Size = 2112 };
+			var formatter = new SearchRequestFormatter(localConnection, mapping, request);
+
+			await localConnection.Search(
+				localConnection.Index ?? "_all",
+				request.DocumentType,
+				formatter.Body,
+				request,
+				log);
+
+			Assert.Equal(4, log.Messages.Count);
+			Assert.Equal(@"[VERBOSE] Request: POST http://localhost/SearchIndex/abc123/_search", log.Messages[0]);
+			Assert.Equal(@"[VERBOSE] Body:" + '\n' + @"{""size"":2112,""timeout"":""10s""}", log.Messages[1]);
+			Assert.True(new Regex(@"\[VERBOSE\] Response: 200 OK \(in \d+ms\)").Match(log.Messages[2]).Success);
+			Assert.True(new Regex(@"\[VERBOSE\] Deserialized \d+ bytes into 1 hits in \d+ms").Match(log.Messages[3]).Success);
+		}
+
+		[Fact]
+		public static void ParseResponseReturnsParsedResponseGivenValidStream()
+		{
+			const int took = 2;
+			const int shards = 1;
+			const int hits = 1;
+			const double score = 0.3141;
+			const string index = "testIndex";
+			const string type = "testType";
+			const string id = "testId";
+
+			var responseString = BuildResponseString(took, shards, hits, score, index, type, id);
+
+			using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(responseString)))
+			{
+				var response = ElasticConnection.ParseResponse(stream, log);
+				Assert.NotNull(response);
+				Assert.Equal(took, response.took);
+				Assert.Equal(hits, response.hits.total);
+				Assert.Equal(score, response.hits.max_score);
+
+				Assert.NotEmpty(response.hits.hits);
+				Assert.Equal(score, response.hits.hits[0]._score);
+				Assert.Equal(index, response.hits.hits[0]._index);
+				Assert.Equal(type, response.hits.hits[0]._type);
+				Assert.Equal(id, response.hits.hits[0]._id);
+			}
+		}
+
+		private static string BuildResponseString(int took, int shards, int hits, double score, string index, string type, string id)
+		{
+			return "{\"took\":" + took + "," +
+								 "\"timed_out\":false," +
+								 "\"_shards\":{\"total\":" + shards + "," +
+								 "\"successful\":" + shards + "" +
+								 ",\"failed\":0}," +
+								 "\"hits\":{\"total\":" + hits + "," +
+								 "\"max_score\":" + score + ",\"hits\":" +
+								 "[{\"_index\":\"" + index + "\"," +
+								 "\"_type\":\"" + type + "\"," +
+								 "\"_id\":\"" + id + "\"," +
+								 "\"_score\":" + score + "," +
+								 "\"fields\":{\"name\":\"testField\"}}]}}";
+		}
 
         public class MyConnection : ElasticConnection
         {

--- a/Source/ElasticLINQ.Test/ElasticConnectionTests.cs
+++ b/Source/ElasticLINQ.Test/ElasticConnectionTests.cs
@@ -140,7 +140,7 @@ namespace ElasticLinq.Test
 			var request = new SearchRequest { DocumentType = "docType" };
 			var formatter = new SearchRequestFormatter(localConnection, mapping, request);
 
-			await localConnection.Search(
+			await localConnection.SearchAsync(
 				formatter.Body,
 				request,
 				log);
@@ -156,7 +156,7 @@ namespace ElasticLinq.Test
 			var request = new SearchRequest { DocumentType = "docType" };
 			var formatter = new SearchRequestFormatter(localConnection, mapping, request);
 
-			await localConnection.Search(
+			await localConnection.SearchAsync(
 				formatter.Body,
 				request,
 				log);
@@ -176,7 +176,7 @@ namespace ElasticLinq.Test
 			var request = new SearchRequest { DocumentType = "docType" };
 			var formatter = new SearchRequestFormatter(localConnection, mapping, request);
 
-			var ex = await Record.ExceptionAsync(() => localConnection.Search(
+			var ex = await Record.ExceptionAsync(() => localConnection.SearchAsync(
 				formatter.Body,
 				request,
 				log));
@@ -196,7 +196,7 @@ namespace ElasticLinq.Test
 			var request = new SearchRequest { DocumentType = "abc123", Size = 2112 };
 			var formatter = new SearchRequestFormatter(localConnection, mapping, request);
 
-			await localConnection.Search(
+			await localConnection.SearchAsync(
 				formatter.Body,
 				request,
 				log);

--- a/Source/ElasticLINQ.Test/ElasticQueryProviderTests.cs
+++ b/Source/ElasticLINQ.Test/ElasticQueryProviderTests.cs
@@ -19,7 +19,7 @@ namespace ElasticLinq.Test
         private static readonly IRetryPolicy retryPolicy = NullRetryPolicy.Instance;
 
         private static readonly ElasticQueryProvider sharedProvider = new ElasticQueryProvider(connection, mapping, log,
-            retryPolicy, "prefix");
+			retryPolicy, "prefix");
 
         private static readonly Expression validExpression =
             Expression.Constant(new ElasticQuery<Sample>(sharedProvider));
@@ -30,7 +30,7 @@ namespace ElasticLinq.Test
         [Fact]
         public void CreateQueryTReturnsElasticQueryTWithProviderSet()
         {
-            var provider = new ElasticQueryProvider(connection, mapping, log, retryPolicy, "prefix");
+			var provider = new ElasticQueryProvider(connection, mapping, log, retryPolicy, "prefix");
 
             var query = provider.CreateQuery<Sample>(validExpression);
 
@@ -41,7 +41,7 @@ namespace ElasticLinq.Test
         [Fact]
         public void CreateQueryReturnsElasticQueryWithProviderSet()
         {
-            var provider = new ElasticQueryProvider(connection, mapping, log, retryPolicy, "prefix");
+			var provider = new ElasticQueryProvider(connection, mapping, log, retryPolicy, "prefix");
 
             var query = provider.CreateQuery(validExpression);
 
@@ -52,7 +52,7 @@ namespace ElasticLinq.Test
         [Fact]
         public void CreateQueryThrowsArgumentOutOfRangeIfExpressionTypeNotAssignableFromIQueryable()
         {
-            var provider = new ElasticQueryProvider(connection, mapping, log, retryPolicy, "prefix");
+			var provider = new ElasticQueryProvider(connection, mapping, log, retryPolicy, "prefix");
 
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => provider.CreateQuery<Sample>(Expression.Constant(new Sample())));

--- a/Source/ElasticLINQ.Test/ElasticQueryTests.cs
+++ b/Source/ElasticLINQ.Test/ElasticQueryTests.cs
@@ -13,7 +13,12 @@ namespace ElasticLinq.Test
     public class ElasticQueryTests
     {
         private static readonly ElasticConnection connection = new ElasticConnection(new Uri("http://localhost"));
-        private static readonly ElasticQueryProvider provider = new ElasticQueryProvider(connection, new TrivialElasticMapping(), NullLog.Instance, NullRetryPolicy.Instance, "prefix");
+		private static readonly ElasticQueryProvider provider = new ElasticQueryProvider(
+			connection,
+			new TrivialElasticMapping(),
+			NullLog.Instance,
+			NullRetryPolicy.Instance,
+			"prefix");
         private static readonly Expression validConstantExpression = Expression.Constant(new ElasticQuery<Sample>(provider));
 
         private class Sample

--- a/Source/ElasticLINQ.Test/Integration/BasicConnectionTests.cs
+++ b/Source/ElasticLINQ.Test/Integration/BasicConnectionTests.cs
@@ -11,6 +11,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using ElasticLinq.Request;
 using Xunit;
 
 namespace ElasticLinq.Test.Integration
@@ -83,7 +84,7 @@ namespace ElasticLinq.Test.Integration
         {
             using (var httpStub = new HttpStub(ZeroHits, 1))
             {
-                var provider = new ElasticQueryProvider(new ElasticConnection(httpStub.Uri), mapping, log, retryPolicy, "prefix");
+				var provider = new ElasticQueryProvider(new ElasticConnection(httpStub.Uri), mapping, log, retryPolicy, "prefix");
                 var query = new ElasticQuery<Robot>(provider);
 
                 provider.Execute(query.Expression);
@@ -100,7 +101,7 @@ namespace ElasticLinq.Test.Integration
         {
             using (var httpStub = new HttpStub(ZeroHits, 1))
             {
-                var provider = new ElasticQueryProvider(new ElasticConnection(httpStub.Uri), mapping, log, retryPolicy, "prefix");
+				var provider = new ElasticQueryProvider(new ElasticConnection(httpStub.Uri), mapping, log, retryPolicy, "prefix");
                 var query = new ElasticQuery<Robot>(provider);
 
                 provider.Execute<IEnumerable<Robot>>(query.Expression);
@@ -117,7 +118,7 @@ namespace ElasticLinq.Test.Integration
         {
             using (var httpStub = new HttpStub(ZeroHits, 1))
             {
-                var provider = new ElasticQueryProvider(new ElasticConnection(httpStub.Uri), mapping, log, retryPolicy, "prefix");
+				var provider = new ElasticQueryProvider(new ElasticConnection(httpStub.Uri), mapping, log, retryPolicy, "prefix");
                 var query = new ElasticQuery<Robot>(provider);
 
                 var enumerator = query.GetEnumerator();
@@ -135,7 +136,7 @@ namespace ElasticLinq.Test.Integration
         {
             using (var httpStub = new HttpStub(ZeroHits, 1))
             {
-                var provider = new ElasticQueryProvider(new ElasticConnection(httpStub.Uri), mapping, log, retryPolicy, "prefix");
+				var provider = new ElasticQueryProvider(new ElasticConnection(httpStub.Uri), mapping, log, retryPolicy, "prefix");
                 var query = new ElasticQuery<Robot>(provider);
 
                 var enumerator = ((IEnumerable)query).GetEnumerator();
@@ -153,7 +154,7 @@ namespace ElasticLinq.Test.Integration
         {
             using (var httpStub = new HttpStub(ZeroHits, 1))
             {
-                var provider = new ElasticQueryProvider(new ElasticConnection(httpStub.Uri), mapping, log, retryPolicy, "prefix");
+				var provider = new ElasticQueryProvider(new ElasticConnection(httpStub.Uri), mapping, log, retryPolicy, "prefix");
                 var query = new ElasticQuery<Robot>(provider).Where(f => false);
 
                 ((IEnumerable)query).GetEnumerator();
@@ -164,7 +165,7 @@ namespace ElasticLinq.Test.Integration
 
         private static ElasticContext MakeElasticContext(Uri uri)
         {
-            return new ElasticContext(new ElasticConnection(uri), mapping, log, retryPolicy);
+			return new ElasticContext(new ElasticConnection(uri), mapping, log, retryPolicy);
         }
 
         private static void ZeroHits(HttpListenerContext context)

--- a/Source/ElasticLINQ.Test/Request/ElasticRequestProcessorTests.cs
+++ b/Source/ElasticLINQ.Test/Request/ElasticRequestProcessorTests.cs
@@ -4,14 +4,9 @@ using ElasticLinq.Logging;
 using ElasticLinq.Mapping;
 using ElasticLinq.Request;
 using ElasticLinq.Retry;
-using ElasticLinq.Test.Utility;
 using System;
-using System.IO;
-using System.Net;
-using System.Net.Http;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using NSubstitute;
 using Xunit;
 
 namespace ElasticLinq.Test.Request
@@ -26,119 +21,37 @@ namespace ElasticLinq.Test.Request
         [Fact]
         public static void Constructor_GuardClauses()
         {
-            Assert.Throws<ArgumentNullException>(() => new ElasticRequestProcessor(null, mapping, log, retryPolicy));
-            Assert.Throws<ArgumentNullException>(() => new ElasticRequestProcessor(connection, null, log, retryPolicy));
-            Assert.Throws<ArgumentNullException>(() => new ElasticRequestProcessor(connection, mapping, null, retryPolicy));
-            Assert.Throws<ArgumentNullException>(() => new ElasticRequestProcessor(connection, mapping, log, null));
+			Assert.Throws<ArgumentNullException>(() => new ElasticRequestProcessor(null, mapping, log, retryPolicy));
+			Assert.Throws<ArgumentNullException>(() => new ElasticRequestProcessor(connection, null, log, retryPolicy));
+			Assert.Throws<ArgumentNullException>(() => new ElasticRequestProcessor(connection, mapping, null, retryPolicy));
+			Assert.Throws<ArgumentNullException>(() => new ElasticRequestProcessor(connection, mapping, log, null));
         }
 
-        [Fact]
-        public static async Task NoAuthorizationWithEmptyUserName()
-        {
-            var messageHandler = new SpyMessageHandler();
-            var localConnection = new ElasticConnection(messageHandler, new Uri("http://localhost"));
-            var processor = new ElasticRequestProcessor(localConnection, mapping, log, retryPolicy);
-            var request = new SearchRequest { DocumentType = "docType" };
+	    [Fact]
+	    public static async Task ShouldCallElasticSearchClient()
+	    {
+			var log = new SpyLog();
 
-            await processor.SearchAsync(request);
+		    var connection = Substitute.For<IElasticConnection>();
 
-            Assert.Null(messageHandler.Request.Headers.Authorization);
-        }
+		    connection.Endpoint.Returns(new Uri("http://localhost"));
+			connection.Index.Returns("SearchIndex");
+			connection.Options.Returns(new ElasticConnectionOptions());
+			connection.Timeout.Returns(TimeSpan.FromSeconds(10));
 
-        [Fact]
-        public static async Task ForcesBasicAuthorizationWhenProvidedWithUsernameAndPassword()
-        {
-            var messageHandler = new SpyMessageHandler();
-            var localConnection = new ElasticConnection(messageHandler, new Uri("http://localhost"), "myUser", "myPass");
-            var processor = new ElasticRequestProcessor(localConnection, mapping, log, retryPolicy);
-            var request = new SearchRequest { DocumentType = "docType" };
+			var request = new SearchRequest { DocumentType = "abc123", Size = 2112 };
 
-            await processor.SearchAsync(request);
+			var processor = new ElasticRequestProcessor(connection, mapping, log, retryPolicy);
+			
+			await processor.SearchAsync(request);
 
-            var auth = messageHandler.Request.Headers.Authorization;
-            Assert.NotNull(auth);
-            Assert.Equal("Basic", auth.Scheme);
-            Assert.Equal("myUser:myPass", Encoding.ASCII.GetString(Convert.FromBase64String(auth.Parameter)));
-        }
-
-        [Fact]
-        public static async void NonSuccessfulHttpRequestThrows()
-        {
-            var messageHandler = new SpyMessageHandler();
-            messageHandler.Response.StatusCode = HttpStatusCode.NotFound;
-            var localConnection = new ElasticConnection(messageHandler, new Uri("http://localhost"), "myUser", "myPass");
-            var processor = new ElasticRequestProcessor(localConnection, mapping, log, retryPolicy);
-            var request = new SearchRequest { DocumentType = "docType" };
-
-            var ex = await Record.ExceptionAsync(() => processor.SearchAsync(request));
-
-            Assert.IsType<HttpRequestException>(ex);
-            Assert.Equal("Response status code does not indicate success: 404 (Not Found).", ex.Message);
-        }
-
-        [Fact]
-        public static void ParseResponseReturnsParsedResponseGivenValidStream()
-        {
-            const int took = 2;
-            const int shards = 1;
-            const int hits = 1;
-            const double score = 0.3141;
-            const string index = "testIndex";
-            const string type = "testType";
-            const string id = "testId";
-
-            var responseString = BuildResponseString(took, shards, hits, score, index, type, id);
-
-            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(responseString)))
-            {
-                var response = ElasticRequestProcessor.ParseResponse(stream, log);
-                Assert.NotNull(response);
-                Assert.Equal(took, response.took);
-                Assert.Equal(hits, response.hits.total);
-                Assert.Equal(score, response.hits.max_score);
-
-                Assert.NotEmpty(response.hits.hits);
-                Assert.Equal(score, response.hits.hits[0]._score);
-                Assert.Equal(index, response.hits.hits[0]._index);
-                Assert.Equal(type, response.hits.hits[0]._type);
-                Assert.Equal(id, response.hits.hits[0]._id);
-            }
-        }
-
-        [Fact]
-        public static async Task LogsDebugMessagesDuringExecution()
-        {
-            var responseString = BuildResponseString(2, 1, 1, 0.3141, "testIndex", "testType", "testId");
-            var messageHandler = new SpyMessageHandler();
-            var log = new SpyLog();
-            messageHandler.Response.Content = new StringContent(responseString);
-            var localConnection = new ElasticConnection(messageHandler, new Uri("http://localhost"), "myUser", "myPass", index: "SearchIndex");
-            var processor = new ElasticRequestProcessor(localConnection, mapping, log, retryPolicy);
-            var request = new SearchRequest { DocumentType = "abc123", Size = 2112 };
-
-            await processor.SearchAsync(request);
-
-            Assert.Equal(4, log.Messages.Count);
-            Assert.Equal(@"[VERBOSE] Request: POST http://localhost/SearchIndex/abc123/_search", log.Messages[0]);
-            Assert.Equal(@"[VERBOSE] Body:" +'\n' + @"{""size"":2112,""timeout"":""10s""}", log.Messages[1]);
-            Assert.True(new Regex(@"\[VERBOSE\] Response: 200 OK \(in \d+ms\)").Match(log.Messages[2]).Success);
-            Assert.True(new Regex(@"\[VERBOSE\] Deserialized \d+ bytes into 1 hits in \d+ms").Match(log.Messages[3]).Success);
-        }
-
-        private static string BuildResponseString(int took, int shards, int hits, double score, string index, string type, string id)
-        {
-            return "{\"took\":" + took + "," +
-                                 "\"timed_out\":false," +
-                                 "\"_shards\":{\"total\":" + shards + "," +
-                                 "\"successful\":" + shards + "" +
-                                 ",\"failed\":0}," +
-                                 "\"hits\":{\"total\":" + hits + "," +
-                                 "\"max_score\":" + score + ",\"hits\":" +
-                                 "[{\"_index\":\"" + index + "\"," +
-                                 "\"_type\":\"" + type + "\"," +
-                                 "\"_id\":\"" + id + "\"," +
-                                 "\"_score\":" + score + "," +
-                                 "\"fields\":{\"name\":\"testField\"}}]}}";
-        }
+			connection.Received(1).Search(
+			   "SearchIndex",
+			   "abc123",
+			   @"{""size"":2112,""timeout"":""10s""}",
+			   request,
+			   log
+			   );
+	    }
     }
 }

--- a/Source/ElasticLINQ.Test/Request/ElasticRequestProcessorTests.cs
+++ b/Source/ElasticLINQ.Test/Request/ElasticRequestProcessorTests.cs
@@ -30,24 +30,24 @@ namespace ElasticLinq.Test.Request
 	    [Fact]
 	    public static async Task ShouldCallElasticSearchClient()
 	    {
-			var log = new SpyLog();
+			var spyLog = new SpyLog();
 
-		    var connection = Substitute.For<IElasticConnection>();
+		    var mockConnection = Substitute.For<IElasticConnection>();
 
-			connection.Index.Returns("SearchIndex");
-			connection.Options.Returns(new ElasticConnectionOptions());
-			connection.Timeout.Returns(TimeSpan.FromSeconds(10));
+			mockConnection.Index.Returns("SearchIndex");
+			mockConnection.Options.Returns(new ElasticConnectionOptions());
+			mockConnection.Timeout.Returns(TimeSpan.FromSeconds(10));
 
 			var request = new SearchRequest { DocumentType = "abc123", Size = 2112 };
 
-			var processor = new ElasticRequestProcessor(connection, mapping, log, retryPolicy);
+			var processor = new ElasticRequestProcessor(mockConnection, mapping, spyLog, retryPolicy);
 			
 			await processor.SearchAsync(request);
 
-			connection.Received(1).Search(
+			mockConnection.Received(1).SearchAsync(
 			   @"{""size"":2112,""timeout"":""10s""}",
 			   request,
-			   log
+			   spyLog
 			   );
 	    }
     }

--- a/Source/ElasticLINQ.Test/Request/ElasticRequestProcessorTests.cs
+++ b/Source/ElasticLINQ.Test/Request/ElasticRequestProcessorTests.cs
@@ -34,7 +34,6 @@ namespace ElasticLinq.Test.Request
 
 		    var connection = Substitute.For<IElasticConnection>();
 
-		    connection.Endpoint.Returns(new Uri("http://localhost"));
 			connection.Index.Returns("SearchIndex");
 			connection.Options.Returns(new ElasticConnectionOptions());
 			connection.Timeout.Returns(TimeSpan.FromSeconds(10));
@@ -46,8 +45,6 @@ namespace ElasticLinq.Test.Request
 			await processor.SearchAsync(request);
 
 			connection.Received(1).Search(
-			   "SearchIndex",
-			   "abc123",
 			   @"{""size"":2112,""timeout"":""10s""}",
 			   request,
 			   log

--- a/Source/ElasticLINQ.Test/Request/Formatters/SearchRequestFormatterTests.cs
+++ b/Source/ElasticLINQ.Test/Request/Formatters/SearchRequestFormatterTests.cs
@@ -30,19 +30,6 @@ namespace ElasticLinq.Test.Request.Formatters
                    .ReturnsForAnyArgs(callInfo => new JValue(String.Format("!!! {0} !!!", callInfo.Arg<object>(1))));
         }
 
-        [Theory]
-        [InlineData(null, null, "http://a.b.com:9000/_all/_search")]
-        [InlineData("index1,index2", null, "http://a.b.com:9000/index1,index2/_search")]
-        [InlineData(null, "docType1,docType2", "http://a.b.com:9000/_all/docType1,docType2/_search")]
-        [InlineData("index1,index2", "docType1,docType2", "http://a.b.com:9000/index1,index2/docType1,docType2/_search")]
-        public void UriFormatting(string index, string documentType, string expectedUri)
-        {
-            var connection = new ElasticConnection(new Uri("http://a.b.com:9000/"), index: index);
-            var formatter = new SearchRequestFormatter(connection, mapping, new SearchRequest { DocumentType = documentType });
-
-            Assert.Equal(expectedUri, formatter.Uri.ToString());
-        }
-
         [Fact]
         public void BodyIsValidJsonFormattedResponse()
         {
@@ -194,43 +181,6 @@ namespace ElasticLinq.Test.Request.Formatters
         }
 
         [Fact]
-        public void PrettySetsUriQueryWhenNoOtherQueryUriParameters()
-        {
-            var prettyUri = new SearchRequestFormatter(
-                new ElasticConnection(new Uri("http://coruscant.gov/some"), options: new ElasticConnectionOptions { Pretty = true }),
-                mapping, new SearchRequest { DocumentType = "type1", Filter = criteria }).Uri;
-
-            Assert.Equal("pretty=true", prettyUri.GetComponents(UriComponents.Query, UriFormat.Unescaped));
-        }
-
-        [Fact]
-        public void PrettyAppendsUriQueryParameterWhenOtherQueryUriParameters()
-        {
-            var prettyUri = new SearchRequestFormatter(
-                new ElasticConnection(new Uri("http://coruscant.gov/some?human=false"), options: new ElasticConnectionOptions { Pretty = true }),
-                mapping, new SearchRequest { DocumentType = "type1", Filter = criteria }).Uri;
-
-            var parameters = prettyUri.GetComponents(UriComponents.Query, UriFormat.Unescaped).Split('&');
-            Assert.Equal(2, parameters.Length);
-            Assert.Contains("human=false", parameters);
-            Assert.Contains("pretty=true", parameters);
-        }
-
-
-        [Fact]
-        public void PrettyChangesUriQueryParameterWhenDifferentValueAlreadyExists()
-        {
-            var prettyUri = new SearchRequestFormatter(
-                new ElasticConnection(new Uri("http://coruscant.gov/some?pretty=false&human=true"), options: new ElasticConnectionOptions { Pretty = true }),
-                mapping, new SearchRequest { DocumentType = "type1", Filter = criteria }).Uri;
-
-            var parameters = prettyUri.GetComponents(UriComponents.Query, UriFormat.Unescaped).Split('&');
-            Assert.Equal(2, parameters.Length);
-            Assert.Contains("human=true", parameters);
-            Assert.Contains("pretty=true", parameters);
-        }
-
-        [Fact]
         public void BodyContainsFromWhenSpecified()
         {
             const int expectedFrom = 1024;
@@ -328,30 +278,6 @@ namespace ElasticLinq.Test.Request.Formatters
             var actual = SearchRequestFormatter.Format(timespan);
 
             Assert.Equal(timespan.TotalMinutes.ToString(CultureInfo.InvariantCulture) + "m", actual);
-        }
-
-        [Fact]
-        public void SearchTypeAppearsOnUriWhenSpecified()
-        {
-            var searchRequest = new SearchRequest { SearchType = "count" };
-
-            var formatter = new SearchRequestFormatter(defaultConnection, mapping, searchRequest);
-
-            var parameters = formatter.Uri.GetComponents(UriComponents.Query, UriFormat.Unescaped).Split('&');
-
-            Assert.Single(parameters, p => p == "search_type=count");
-        }
-
-        [Fact]
-        public void SearchTypeDoesNotAppearOnUriWhenNotSpecified()
-        {
-            var searchRequest = new SearchRequest { SearchType = "" };
-
-            var formatter = new SearchRequestFormatter(defaultConnection, mapping, searchRequest);
-
-            var parameters = formatter.Uri.GetComponents(UriComponents.Query, UriFormat.Unescaped).Split('&');
-
-            Assert.DoesNotContain(parameters, p => p.StartsWith("search_type="));
         }
     }
 }

--- a/Source/ElasticLINQ.Test/Request/Visitors/ElasticQueryTranslation/ElasticQueryTranslationTestsBase.cs
+++ b/Source/ElasticLINQ.Test/Request/Visitors/ElasticQueryTranslation/ElasticQueryTranslationTestsBase.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using ElasticLinq.Request;
+using NSubstitute;
 
 namespace ElasticLinq.Test.Request.Visitors.ElasticQueryTranslation
 {

--- a/Source/ElasticLINQ/BaseElasticConnection.cs
+++ b/Source/ElasticLINQ/BaseElasticConnection.cs
@@ -69,7 +69,7 @@ namespace ElasticLinq
 		/// <param name="searchRequest">The search request settings</param>
 		/// <param name="log">The logging mechanism for diagnostic information.</param>
 		/// <returns>An elastic response</returns>
-		public abstract Task<ElasticResponse> Search(string body, SearchRequest searchRequest, ILog log);
+		public abstract Task<ElasticResponse> SearchAsync(string body, SearchRequest searchRequest, ILog log);
 
 		/// <summary>
 		/// Gets the uri of the search

--- a/Source/ElasticLINQ/BaseElasticConnection.cs
+++ b/Source/ElasticLINQ/BaseElasticConnection.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Threading.Tasks;
+using ElasticLinq.Logging;
+using ElasticLinq.Request;
+using ElasticLinq.Response.Model;
+using ElasticLinq.Utility;
+
+namespace ElasticLinq
+{
+	/// <summary>
+	/// Specifies connection parameters for Elasticsearch.
+	/// </summary>
+	public abstract class BaseElasticConnection : IElasticConnection
+	{
+		private static readonly TimeSpan defaultTimeout = TimeSpan.FromSeconds(10);
+
+		private readonly Uri endpoint;
+		private readonly string index;
+		private readonly TimeSpan timeout;
+		private readonly ElasticConnectionOptions options;
+
+		/// <summary>
+		/// Create a new BaseElasticConnection with the given parameters for internal testing.
+		/// </summary>
+		/// <param name="endpoint">The URL endpoint of the Elasticsearch server.</param>
+		/// <param name="timeout">TimeSpan to wait for network responses before failing (optional, defaults to 10 seconds).</param>
+		/// <param name="index">Name of the index to use on the server (optional).</param>
+		/// <param name="options">Additional options that specify how this connection should behave.</param>
+		protected BaseElasticConnection(Uri endpoint, string index = null, TimeSpan? timeout = null, ElasticConnectionOptions options = null)
+        {
+            Argument.EnsureNotNull("endpoint", endpoint);
+
+            if (timeout.HasValue)
+                Argument.EnsurePositive("value", timeout.Value);
+            if (index != null)
+                Argument.EnsureNotBlank("index", index);
+
+            this.endpoint = endpoint;
+            this.index = index;
+            this.options = options ?? new ElasticConnectionOptions();
+            this.timeout = timeout ?? defaultTimeout;
+        }
+
+		/// <summary>
+		/// The Uri that specifies the public endpoint for the server.
+		/// </summary>
+		/// <example>http://myserver.example.com:9200</example>
+		public Uri Endpoint
+		{
+			get { return endpoint; }
+		}
+
+		/// <summary>
+		/// The name of the index on the Elasticsearch server.
+		/// </summary>
+		/// <example>northwind</example>
+		public string Index
+		{
+			get { return index; }
+		}
+
+		/// <summary>
+		/// How long to wait for a response to a network request before
+		/// giving up.
+		/// </summary>
+		public TimeSpan Timeout
+		{
+			get { return timeout; }
+		}
+
+		/// <summary>
+		/// Additional options that specify how this connection should behave.
+		/// </summary>
+		public ElasticConnectionOptions Options
+		{
+			get { return options; }
+		}
+
+		/// <summary>
+		/// Issues search requests to elastic search
+		/// </summary>
+		/// <param name="searchIndex">The elastic search index</param>
+		/// <param name="document">The elastic search document</param>
+		/// <param name="body">The request body</param>
+		/// <param name="searchRequest">The search request settings</param>
+		/// <param name="log">The logging mechanism for diagnostic information.</param>
+		/// <returns>An elastic response</returns>
+		public abstract Task<ElasticResponse> Search(string searchIndex, string document, string body, SearchRequest searchRequest, ILog log);
+	}
+}

--- a/Source/ElasticLINQ/BaseElasticConnection.cs
+++ b/Source/ElasticLINQ/BaseElasticConnection.cs
@@ -14,7 +14,6 @@ namespace ElasticLinq
 	{
 		private static readonly TimeSpan defaultTimeout = TimeSpan.FromSeconds(10);
 
-		private readonly Uri endpoint;
 		private readonly string index;
 		private readonly TimeSpan timeout;
 		private readonly ElasticConnectionOptions options;
@@ -22,33 +21,20 @@ namespace ElasticLinq
 		/// <summary>
 		/// Create a new BaseElasticConnection with the given parameters for internal testing.
 		/// </summary>
-		/// <param name="endpoint">The URL endpoint of the Elasticsearch server.</param>
 		/// <param name="timeout">TimeSpan to wait for network responses before failing (optional, defaults to 10 seconds).</param>
 		/// <param name="index">Name of the index to use on the server (optional).</param>
 		/// <param name="options">Additional options that specify how this connection should behave.</param>
-		protected BaseElasticConnection(Uri endpoint, string index = null, TimeSpan? timeout = null, ElasticConnectionOptions options = null)
+		protected BaseElasticConnection(string index = null, TimeSpan? timeout = null, ElasticConnectionOptions options = null)
         {
-            Argument.EnsureNotNull("endpoint", endpoint);
-
             if (timeout.HasValue)
                 Argument.EnsurePositive("value", timeout.Value);
             if (index != null)
                 Argument.EnsureNotBlank("index", index);
 
-            this.endpoint = endpoint;
             this.index = index;
             this.options = options ?? new ElasticConnectionOptions();
             this.timeout = timeout ?? defaultTimeout;
         }
-
-		/// <summary>
-		/// The Uri that specifies the public endpoint for the server.
-		/// </summary>
-		/// <example>http://myserver.example.com:9200</example>
-		public Uri Endpoint
-		{
-			get { return endpoint; }
-		}
 
 		/// <summary>
 		/// The name of the index on the Elasticsearch server.
@@ -79,12 +65,17 @@ namespace ElasticLinq
 		/// <summary>
 		/// Issues search requests to elastic search
 		/// </summary>
-		/// <param name="searchIndex">The elastic search index</param>
-		/// <param name="document">The elastic search document</param>
 		/// <param name="body">The request body</param>
 		/// <param name="searchRequest">The search request settings</param>
 		/// <param name="log">The logging mechanism for diagnostic information.</param>
 		/// <returns>An elastic response</returns>
-		public abstract Task<ElasticResponse> Search(string searchIndex, string document, string body, SearchRequest searchRequest, ILog log);
+		public abstract Task<ElasticResponse> Search(string body, SearchRequest searchRequest, ILog log);
+
+		/// <summary>
+		/// Gets the uri of the search
+		/// </summary>
+		/// <param name="searchRequest">The search request settings</param>
+		/// <returns>The uri of the search</returns>
+		public abstract Uri GetSearchUri(SearchRequest searchRequest);
 	}
 }

--- a/Source/ElasticLINQ/ElasticConnection.cs
+++ b/Source/ElasticLINQ/ElasticConnection.cs
@@ -2,9 +2,17 @@
 
 using ElasticLinq.Utility;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
+using ElasticLinq.Logging;
+using ElasticLinq.Request;
+using ElasticLinq.Response.Model;
+using Newtonsoft.Json;
 
 namespace ElasticLinq
 {
@@ -12,14 +20,10 @@ namespace ElasticLinq
     /// Specifies connection parameters for Elasticsearch.
     /// </summary>
     [DebuggerDisplay("{Endpoint.ToString(),nq}{Index,nq}")]
-    public class ElasticConnection : IDisposable
+	public class ElasticConnection : BaseElasticConnection, IDisposable
     {
-        private static readonly TimeSpan defaultTimeout = TimeSpan.FromSeconds(10);
+		private readonly string[] parameterSeparator = { "&" };
 
-        private readonly Uri endpoint;
-        private readonly string index;
-        private readonly TimeSpan timeout;
-        private readonly ElasticConnectionOptions options;
         private HttpClient httpClient;
 
         /// <summary>
@@ -46,18 +50,8 @@ namespace ElasticLinq
         /// <param name="index">Name of the index to use on the server (optional).</param>
         /// <param name="options">Additional options that specify how this connection should behave.</param>
         internal ElasticConnection(HttpMessageHandler innerMessageHandler, Uri endpoint, string userName = null, string password = null, string index = null, TimeSpan? timeout = null, ElasticConnectionOptions options = null)
+			: base(endpoint, index, timeout, options)
         {
-            Argument.EnsureNotNull("endpoint", endpoint);
-            if (timeout.HasValue)
-                Argument.EnsurePositive("value", timeout.Value);
-            if (index != null)
-                Argument.EnsureNotBlank("index", index);
-
-            this.endpoint = endpoint;
-            this.index = index;
-            this.options = options ?? new ElasticConnectionOptions();
-            this.timeout = timeout ?? defaultTimeout;
-
             var httpClientHandler = innerMessageHandler as HttpClientHandler;
             if (httpClientHandler != null && httpClientHandler.SupportsAutomaticDecompression)
                 httpClientHandler.AutomaticDecompression = DecompressionMethods.GZip;
@@ -71,41 +65,6 @@ namespace ElasticLinq
         internal HttpClient HttpClient
         {
             get { return httpClient; }
-        }
-
-        /// <summary>
-        /// The Uri that specifies the public endpoint for the server.
-        /// </summary>
-        /// <example>http://myserver.example.com:9200</example>
-        public Uri Endpoint
-        {
-            get { return endpoint; }
-        }
-
-        /// <summary>
-        /// The name of the index on the Elasticsearch server.
-        /// </summary>
-        /// <example>northwind</example>
-        public string Index
-        {
-            get { return index; }
-        }
-
-        /// <summary>
-        /// How long to wait for a response to a network request before
-        /// giving up.
-        /// </summary>
-        public TimeSpan Timeout
-        {
-            get { return timeout; }
-        }
-
-        /// <summary>
-        /// Additional options that specify how this connection should behave.
-        /// </summary>
-        public ElasticConnectionOptions Options
-        {
-            get { return options; }
         }
 
         /// <summary>
@@ -129,5 +88,102 @@ namespace ElasticLinq
                 }
             }
         }
+
+	    /// <summary>
+	    /// Issues search requests to elastic search
+	    /// </summary>
+	    /// <param name="searchIndex">The elastic search index</param>
+	    /// <param name="document">The elastic search document</param>
+	    /// <param name="body">The request body</param>
+	    /// <param name="searchRequest">The search request settings</param>
+	    /// <param name="log">The logging mechanism for diagnostic information.</param>
+	    /// <returns>An elastic response</returns>
+	    public override async Task<ElasticResponse> Search(
+			string searchIndex,
+			string document,
+			string body,
+			SearchRequest searchRequest,
+			ILog log)
+	    {
+			var uri = CreateUri(searchIndex, document, searchRequest);
+
+			log.Debug(null, null, "Request: POST {0}", uri);
+			log.Debug(null, null, "Body:\n{0}", body);
+
+			using (var requestMessage = new HttpRequestMessage(HttpMethod.Post, uri) { Content = new StringContent(body) })
+			using (var response = await SendRequestAsync(requestMessage, log))
+			using (var responseStream = await response.Content.ReadAsStreamAsync())
+				return ParseResponse(responseStream, log);
+	    }
+
+		private async Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage requestMessage, ILog log)
+		{
+			var stopwatch = Stopwatch.StartNew();
+			var response = await httpClient.SendAsync(requestMessage);
+			stopwatch.Stop();
+
+			log.Debug(null, null, "Response: {0} {1} (in {2}ms)", (int)response.StatusCode, response.StatusCode, stopwatch.ElapsedMilliseconds);
+
+			response.EnsureSuccessStatusCode();
+			return response;
+		}
+
+		internal static ElasticResponse ParseResponse(Stream responseStream, ILog log)
+		{
+			var stopwatch = Stopwatch.StartNew();
+
+			using (var textReader = new JsonTextReader(new StreamReader(responseStream)))
+			{
+				var results = new JsonSerializer().Deserialize<ElasticResponse>(textReader);
+				stopwatch.Stop();
+
+				var resultSummary = String.Join(", ", GetResultSummary(results));
+				log.Debug(null, null, "Deserialized {0} bytes into {1} in {2}ms", responseStream.Length, resultSummary, stopwatch.ElapsedMilliseconds);
+
+				return results;
+			}
+		}
+
+		internal static IEnumerable<string> GetResultSummary(ElasticResponse results)
+		{
+			if (results == null)
+			{
+				yield return "nothing";
+			}
+			else
+			{
+				if (results.hits != null && results.hits.hits != null && results.hits.hits.Count > 0)
+					yield return results.hits.hits.Count + " hits";
+
+				if (results.facets != null && results.facets.Count > 0)
+					yield return results.facets.Count + " facets";
+			}
+		}
+
+		private Uri CreateUri(
+			string searchIndex,
+			string document,
+			SearchRequest searchRequest)
+		{
+			var builder = new UriBuilder(Endpoint);
+			builder.Path += (searchIndex ?? "_all") + "/";
+
+			if (!String.IsNullOrEmpty(document))
+				builder.Path += document + "/";
+
+			builder.Path += "_search";
+
+			var parameters = builder.Uri.GetComponents(UriComponents.Query, UriFormat.Unescaped)
+				.Split(parameterSeparator, StringSplitOptions.RemoveEmptyEntries)
+				.Select(p => p.Split('='))
+				.ToDictionary(k => k[0], v => v.Length > 1 ? v[1] : null);
+
+			if (!String.IsNullOrEmpty(searchRequest.SearchType))
+				parameters["search_type"] = searchRequest.SearchType;
+
+			builder.Query = String.Join("&", parameters.Select(p => p.Value == null ? p.Key : p.Key + "=" + p.Value));
+
+			return builder.Uri;
+		}
     }
 }

--- a/Source/ElasticLINQ/ElasticConnection.cs
+++ b/Source/ElasticLINQ/ElasticConnection.cs
@@ -110,7 +110,7 @@ namespace ElasticLinq
 	    /// <param name="searchRequest">The search request settings</param>
 	    /// <param name="log">The logging mechanism for diagnostic information.</param>
 	    /// <returns>An elastic response</returns>
-	    public override async Task<ElasticResponse> Search(
+	    public override async Task<ElasticResponse> SearchAsync(
 			string body,
 			SearchRequest searchRequest,
 			ILog log)

--- a/Source/ElasticLINQ/ElasticContext.cs
+++ b/Source/ElasticLINQ/ElasticContext.cs
@@ -5,6 +5,7 @@ using ElasticLinq.Mapping;
 using ElasticLinq.Retry;
 using ElasticLinq.Utility;
 using System.Linq;
+using ElasticLinq.Request;
 
 namespace ElasticLinq
 {
@@ -13,14 +14,14 @@ namespace ElasticLinq
     /// </summary>
     public class ElasticContext : IElasticContext
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ElasticContext"/> class.
-        /// </summary>
-        /// <param name="connection">The information on how to connect to the Elasticsearch server.</param>
-        /// <param name="mapping">The object that helps map queries (optional, defaults to <see cref="TrivialElasticMapping"/>).</param>
-        /// <param name="log">The object which logs information (optional, defaults to <see cref="NullLog"/>).</param>
-        /// <param name="retryPolicy">The object which controls retry policy for the search (optional, defaults to <see cref="RetryPolicy"/>).</param>
-        public ElasticContext(ElasticConnection connection, IElasticMapping mapping = null, ILog log = null, IRetryPolicy retryPolicy = null)
+	    /// <summary>
+	    /// Initializes a new instance of the <see cref="ElasticContext"/> class.
+	    /// </summary>
+	    /// <param name="connection">The information on how to connect to the Elasticsearch server.</param>
+	    /// <param name="mapping">The object that helps map queries (optional, defaults to <see cref="TrivialElasticMapping"/>).</param>
+	    /// <param name="log">The object which logs information (optional, defaults to <see cref="NullLog"/>).</param>
+	    /// <param name="retryPolicy">The object which controls retry policy for the search (optional, defaults to <see cref="RetryPolicy"/>).</param>
+		public ElasticContext(IElasticConnection connection, IElasticMapping mapping = null, ILog log = null, IRetryPolicy retryPolicy = null)
         {
             Argument.EnsureNotNull("connection", connection);
 
@@ -33,7 +34,7 @@ namespace ElasticLinq
         /// <summary>
         /// Specifies the connection to the Elasticsearch server.
         /// </summary>
-        public ElasticConnection Connection { get; private set; }
+		public IElasticConnection Connection { get; private set; }
 
         /// <summary>
         /// The logging mechanism for diagnostic information.

--- a/Source/ElasticLINQ/ElasticLINQ.csproj
+++ b/Source/ElasticLINQ/ElasticLINQ.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BaseElasticConnection.cs" />
     <Compile Include="ElasticConnection.cs" />
     <Compile Include="ElasticConnectionOptions.cs" />
     <Compile Include="ElasticContext.cs" />
@@ -55,6 +56,7 @@
     <Compile Include="ElasticQueryProvider.cs" />
     <Compile Include="IElasticContext.cs" />
     <Compile Include="IElasticQuery.cs" />
+    <Compile Include="IElasticConnection.cs" />
     <Compile Include="Logging\ILog.cs" />
     <Compile Include="Logging\LogExtensions.cs" />
     <Compile Include="Logging\NullLog.cs" />

--- a/Source/ElasticLINQ/ElasticQuery.cs
+++ b/Source/ElasticLINQ/ElasticQuery.cs
@@ -86,7 +86,7 @@ namespace ElasticLinq
             var request = ElasticQueryTranslator.Translate(provider.Mapping, provider.Prefix, Expression);
             var formatter = new SearchRequestFormatter(provider.Connection, provider.Mapping, request.SearchRequest);
 
-            return new QueryInfo(formatter.Body, formatter.Uri);
+			return new QueryInfo(formatter.Body, provider.Connection.GetSearchUri(request.SearchRequest));
         }
     }
 }

--- a/Source/ElasticLINQ/ElasticQueryProvider.cs
+++ b/Source/ElasticLINQ/ElasticQueryProvider.cs
@@ -23,15 +23,15 @@ namespace ElasticLinq
     {
         private readonly ElasticRequestProcessor requestProcessor;
 
-        /// <summary>
-        /// Create a new ElasticQueryProvider for a given connection, mapping, log, retry policy and field prefix.
-        /// </summary>
-        /// <param name="connection">Connection to use to connect to Elasticsearch.</param>
-        /// <param name="mapping">A mapping to specify how queries and results are translated.</param>
-        /// <param name="log">A log to receive any information or debugging messages.</param>
-        /// <param name="retryPolicy">A policy to describe how to handle network issues.</param>
-        /// <param name="prefix">A string to use to prefix all Elasticsearch fields with.</param>
-        public ElasticQueryProvider(ElasticConnection connection, IElasticMapping mapping, ILog log, IRetryPolicy retryPolicy, string prefix)
+	    /// <summary>
+	    /// Create a new ElasticQueryProvider for a given connection, mapping, log, retry policy and field prefix.
+	    /// </summary>
+	    /// <param name="connection">Connection to use to connect to Elasticsearch.</param>
+	    /// <param name="mapping">A mapping to specify how queries and results are translated.</param>
+	    /// <param name="log">A log to receive any information or debugging messages.</param>
+	    /// <param name="retryPolicy">A policy to describe how to handle network issues.</param>
+	    /// <param name="prefix">A string to use to prefix all Elasticsearch fields with.</param>
+		public ElasticQueryProvider(IElasticConnection connection, IElasticMapping mapping, ILog log, IRetryPolicy retryPolicy, string prefix)
         {
             Argument.EnsureNotNull("connection", connection);
             Argument.EnsureNotNull("mapping", mapping);
@@ -47,7 +47,7 @@ namespace ElasticLinq
             requestProcessor = new ElasticRequestProcessor(connection, mapping, log, retryPolicy);
         }
 
-        internal ElasticConnection Connection { get; private set; }
+		internal IElasticConnection Connection { get; private set; }
 
         internal ILog Log { get; private set; }
 

--- a/Source/ElasticLINQ/IElasticConnection.cs
+++ b/Source/ElasticLINQ/IElasticConnection.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Threading.Tasks;
+using ElasticLinq.Logging;
+using ElasticLinq.Request;
+using ElasticLinq.Response.Model;
+
+namespace ElasticLinq
+{
+	/// <summary>
+	/// The interface all clients which make requests to elastic search must implement
+	/// </summary>
+	public interface IElasticConnection
+	{
+		/// <summary>
+		/// The name of the index on the Elasticsearch server.
+		/// </summary>
+		string Index { get; }
+
+		/// <summary>
+		/// Additional options that specify how this connection should behave.
+		/// </summary>
+		ElasticConnectionOptions Options { get; }
+
+		/// <summary>
+		/// How long to wait for a response to a network request before
+		/// giving up.
+		/// </summary>
+		TimeSpan Timeout { get; }
+
+		/// <summary>
+		/// The Uri that specifies the public endpoint for the server.
+		/// </summary>
+		/// <example>http://myserver.example.com:9200</example>
+		Uri Endpoint { get; }
+
+		/// <summary>
+		/// Issues search requests to elastic search
+		/// </summary>
+		/// <param name="searchIndex">The elastic search index</param>
+		/// <param name="document">The elastic search document</param>
+		/// <param name="body">The request body</param>
+		/// <param name="searchRequest">The search request settings</param>
+		/// <param name="log">The logging mechanism for diagnostic information.</param>
+		/// <returns>An elastic response</returns>
+		Task<ElasticResponse> Search(
+			string searchIndex,
+			string document,
+			string body,
+			SearchRequest searchRequest,
+			ILog log);
+	}
+}

--- a/Source/ElasticLINQ/IElasticConnection.cs
+++ b/Source/ElasticLINQ/IElasticConnection.cs
@@ -28,25 +28,22 @@ namespace ElasticLinq
 		TimeSpan Timeout { get; }
 
 		/// <summary>
-		/// The Uri that specifies the public endpoint for the server.
-		/// </summary>
-		/// <example>http://myserver.example.com:9200</example>
-		Uri Endpoint { get; }
-
-		/// <summary>
 		/// Issues search requests to elastic search
 		/// </summary>
-		/// <param name="searchIndex">The elastic search index</param>
-		/// <param name="document">The elastic search document</param>
 		/// <param name="body">The request body</param>
 		/// <param name="searchRequest">The search request settings</param>
 		/// <param name="log">The logging mechanism for diagnostic information.</param>
 		/// <returns>An elastic response</returns>
 		Task<ElasticResponse> Search(
-			string searchIndex,
-			string document,
 			string body,
 			SearchRequest searchRequest,
 			ILog log);
+
+		/// <summary>
+		/// Gets the uri of the search
+		/// </summary>
+		/// <param name="searchRequest">The search request settings</param>
+		/// <returns>The uri of the search</returns>
+		Uri GetSearchUri(SearchRequest searchRequest);
 	}
 }

--- a/Source/ElasticLINQ/IElasticConnection.cs
+++ b/Source/ElasticLINQ/IElasticConnection.cs
@@ -34,7 +34,7 @@ namespace ElasticLinq
 		/// <param name="searchRequest">The search request settings</param>
 		/// <param name="log">The logging mechanism for diagnostic information.</param>
 		/// <returns>An elastic response</returns>
-		Task<ElasticResponse> Search(
+		Task<ElasticResponse> SearchAsync(
 			string body,
 			SearchRequest searchRequest,
 			ILog log);

--- a/Source/ElasticLINQ/Request/ElasticRequestProcessor.cs
+++ b/Source/ElasticLINQ/Request/ElasticRequestProcessor.cs
@@ -39,8 +39,6 @@ namespace ElasticLinq.Request
 
             return retryPolicy.ExecuteAsync(
 				async () => await connection.Search(
-					connection.Index ?? "_all",
-					searchRequest.DocumentType,
 					formatter.Body,
 					searchRequest,
 					log),

--- a/Source/ElasticLINQ/Request/ElasticRequestProcessor.cs
+++ b/Source/ElasticLINQ/Request/ElasticRequestProcessor.cs
@@ -6,12 +6,6 @@ using ElasticLinq.Request.Formatters;
 using ElasticLinq.Response.Model;
 using ElasticLinq.Retry;
 using ElasticLinq.Utility;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace ElasticLinq.Request
@@ -21,12 +15,12 @@ namespace ElasticLinq.Request
     /// </summary>
     internal class ElasticRequestProcessor
     {
-        private readonly ElasticConnection connection;
+        private readonly IElasticConnection connection;
         private readonly ILog log;
         private readonly IElasticMapping mapping;
         private readonly IRetryPolicy retryPolicy;
 
-        public ElasticRequestProcessor(ElasticConnection connection, IElasticMapping mapping, ILog log, IRetryPolicy retryPolicy)
+		public ElasticRequestProcessor(IElasticConnection connection, IElasticMapping mapping, ILog log, IRetryPolicy retryPolicy)
         {
             Argument.EnsureNotNull("connection", connection);
             Argument.EnsureNotNull("mapping", mapping);
@@ -42,67 +36,20 @@ namespace ElasticLinq.Request
         public Task<ElasticResponse> SearchAsync(SearchRequest searchRequest)
         {
             var formatter = new SearchRequestFormatter(connection, mapping, searchRequest);
-            log.Debug(null, null, "Request: POST {0}", formatter.Uri);
-            log.Debug(null, null, "Body:\n{0}", formatter.Body);
 
             return retryPolicy.ExecuteAsync(
-                async () =>
-                {
-                    using (var requestMessage = new HttpRequestMessage(HttpMethod.Post, formatter.Uri) { Content = new StringContent(formatter.Body) })
-                    using (var response = await SendRequestAsync(connection.HttpClient, requestMessage))
-                    using (var responseStream = await response.Content.ReadAsStreamAsync())
-                        return ParseResponse(responseStream, log);
-                },
+				async () => await connection.Search(
+					connection.Index ?? "_all",
+					searchRequest.DocumentType,
+					formatter.Body,
+					searchRequest,
+					log),
                 (response, exception) => exception is TaskCanceledException,
                 (response, additionalInfo) =>
                 {
                     additionalInfo["index"] = connection.Index;
                     additionalInfo["query"] = formatter.Body;
                 });
-        }
-
-        private async Task<HttpResponseMessage> SendRequestAsync(HttpClient httpClient, HttpRequestMessage requestMessage)
-        {
-            var stopwatch = Stopwatch.StartNew();
-            var response = await httpClient.SendAsync(requestMessage);
-            stopwatch.Stop();
-
-            log.Debug(null, null, "Response: {0} {1} (in {2}ms)", (int)response.StatusCode, response.StatusCode, stopwatch.ElapsedMilliseconds);
-
-            response.EnsureSuccessStatusCode();
-            return response;
-        }
-
-        internal static ElasticResponse ParseResponse(Stream responseStream, ILog log)
-        {
-            var stopwatch = Stopwatch.StartNew();
-
-            using (var textReader = new JsonTextReader(new StreamReader(responseStream)))
-            {
-                var results = new JsonSerializer().Deserialize<ElasticResponse>(textReader);
-                stopwatch.Stop();
-
-                var resultSummary = String.Join(", ", GetResultSummary(results));
-                log.Debug(null, null, "Deserialized {0} bytes into {1} in {2}ms", responseStream.Length, resultSummary, stopwatch.ElapsedMilliseconds);
-
-                return results;
-            }
-        }
-
-        private static IEnumerable<string> GetResultSummary(ElasticResponse results)
-        {
-            if (results == null)
-            {
-                yield return "nothing";
-            }
-            else
-            {
-                if (results.hits != null && results.hits.hits != null && results.hits.hits.Count > 0)
-                    yield return results.hits.hits.Count + " hits";
-
-                if (results.facets != null && results.facets.Count > 0)
-                    yield return results.facets.Count + " facets";
-            }
         }
     }
 }

--- a/Source/ElasticLINQ/Request/ElasticRequestProcessor.cs
+++ b/Source/ElasticLINQ/Request/ElasticRequestProcessor.cs
@@ -38,7 +38,7 @@ namespace ElasticLinq.Request
             var formatter = new SearchRequestFormatter(connection, mapping, searchRequest);
 
             return retryPolicy.ExecuteAsync(
-				async () => await connection.Search(
+				async () => await connection.SearchAsync(
 					formatter.Body,
 					searchRequest,
 					log),

--- a/Source/ElasticLINQ/Request/Facets/IFacet.cs
+++ b/Source/ElasticLINQ/Request/Facets/IFacet.cs
@@ -4,15 +4,37 @@ using ElasticLinq.Request.Criteria;
 
 namespace ElasticLinq.Request.Facets
 {
-    internal interface IFacet
+    /// <summary>
+	/// Interface that all facets must implement to be part of
+	/// the query facet tree.
+    /// </summary>
+    public interface IFacet
     {
+        /// <summary>
+        /// Name of this facet as specified in the Elasticsearch DSL
+        /// </summary>
         string Name { get; }
+
+        /// <summary>
+		/// Type of this facet as specified in the Elasticsearch DSL
+        /// </summary>
         string Type { get; }
+
+        /// <summary>
+        /// Criteria of this facet
+        /// </summary>
         ICriteria Filter { get; }
     }
 
-    internal interface IOrderableFacet : IFacet
+	/// <summary>
+	/// Interface that all orderable facets must implement to be part of
+	/// the query facet tree.
+	/// </summary>
+	public interface IOrderableFacet : IFacet
     {
+        /// <summary>
+		/// Defines how many top terms should be returned out of the overall terms list
+        /// </summary>
         int? Size { get; }
     }
 }

--- a/Source/ElasticLINQ/Request/Formatters/SearchRequestFormatter.cs
+++ b/Source/ElasticLINQ/Request/Formatters/SearchRequestFormatter.cs
@@ -23,7 +23,7 @@ namespace ElasticLinq.Request.Formatters
         private readonly string[] parameterSeparator = { "&" };
 
         private readonly Lazy<string> body;
-        private readonly ElasticConnection connection;
+		private readonly IElasticConnection connection;
         private readonly IElasticMapping mapping;
         private readonly SearchRequest searchRequest;
         private readonly Uri uri;
@@ -34,7 +34,7 @@ namespace ElasticLinq.Request.Formatters
         /// <param name="connection">The ElasticConnection to prepare the SearchRequest for.</param>
         /// <param name="mapping">The IElasticMapping used to format the SearchRequest.</param>
         /// <param name="searchRequest">The SearchRequest to be formatted.</param>
-        public SearchRequestFormatter(ElasticConnection connection, IElasticMapping mapping, SearchRequest searchRequest)
+		public SearchRequestFormatter(IElasticConnection connection, IElasticMapping mapping, SearchRequest searchRequest)
         {
             this.connection = connection;
             this.mapping = mapping;

--- a/Source/ElasticLINQ/Request/SearchRequest.cs
+++ b/Source/ElasticLINQ/Request/SearchRequest.cs
@@ -9,7 +9,7 @@ namespace ElasticLinq.Request
     /// <summary>
     /// Represents a search request to be sent to Elasticsearch.
     /// </summary>
-    internal class SearchRequest
+    public class SearchRequest
     {
         /// <summary>
         /// Create a new SearchRequest.

--- a/Source/ElasticLINQ/Request/SortOption.cs
+++ b/Source/ElasticLINQ/Request/SortOption.cs
@@ -7,7 +7,7 @@ namespace ElasticLinq.Request
     /// <summary>
     /// Specifies the options desired for sorting by an individual field.
     /// </summary>
-    internal class SortOption
+    public class SortOption
     {
         private readonly string name;
         private readonly bool ascending;

--- a/Source/ElasticLINQ/Test/TestableElasticQuery.cs
+++ b/Source/ElasticLINQ/Test/TestableElasticQuery.cs
@@ -62,7 +62,7 @@ namespace ElasticLinq.Test
             var prefix = Context.Mapping.GetDocumentMappingPrefix(typeof(T));
             var request = ElasticQueryTranslator.Translate(Context.Mapping, prefix, Expression);
             var formatter = new SearchRequestFormatter(Context.Connection, Context.Mapping, request.SearchRequest);
-            return new QueryInfo(formatter.Body, formatter.Uri);
+			return new QueryInfo(formatter.Body, Context.Connection.GetSearchUri(request.SearchRequest));
         }
     }
 }


### PR DESCRIPTION
Enable the ability to switch between different methods of contacting ElasticSeach. Opens up the ability to use connection pooling via Elasticsearch-net by implementing a new IElasticConnection.
