### PR TITLE
Materilize query results into a batched list to avoid large object heap allocations

### DIFF
--- a/Source/ElasticLINQ.Test/ElasticLINQ.Test.csproj
+++ b/Source/ElasticLINQ.Test/ElasticLINQ.Test.csproj
@@ -160,6 +160,7 @@
     <Compile Include="Test\TestableElasticQueryTests.cs" />
     <Compile Include="Test\TestableElasticContextTests.cs" />
     <Compile Include="Utility\ArgumentTests.cs" />
+    <Compile Include="Utility\ReadOnlyBatchedListTests.cs" />
     <Compile Include="Utility\SpyMessageHandler.cs" />
     <Compile Include="Utility\TypeHelperTests.cs" />
     <Compile Include="..\GlobalAssemblyInfo.cs">

--- a/Source/ElasticLINQ.Test/Response/Materializers/HighlightMaterializerTests.cs
+++ b/Source/ElasticLINQ.Test/Response/Materializers/HighlightMaterializerTests.cs
@@ -38,7 +38,7 @@ namespace ElasticLinq.Test.Response.Materializers
 
             var result = materializer.Materialize(respomse);
 
-            var actualList = Assert.IsType<List<SampleClassWithHighlight>>(result);
+            var actualList = Assert.IsAssignableFrom<IReadOnlyList<SampleClassWithHighlight>>(result);
             var highlighted = actualList.First().SampleField_Highlight;
             Assert.NotNull(highlighted);
         }

--- a/Source/ElasticLINQ.Test/Response/Materializers/ManyHitsElasticMaterializerTests.cs
+++ b/Source/ElasticLINQ.Test/Response/Materializers/ManyHitsElasticMaterializerTests.cs
@@ -31,7 +31,7 @@ namespace ElasticLinq.Test.Response.Materializers
             var materializer = new ListHitsElasticMaterializer(MaterializerTestHelper.ItemCreator, typeof(SampleClass));
             var actual = materializer.Materialize(response);
 
-            var actualList = Assert.IsType<List<SampleClass>>(actual);
+            var actualList = Assert.IsAssignableFrom<IReadOnlyList<SampleClass>>(actual);
 
             Assert.Equal(expected.Count, actualList.Count);
             var index = 0;

--- a/Source/ElasticLINQ.Test/Utility/ReadOnlyBatchedListTests.cs
+++ b/Source/ElasticLINQ.Test/Utility/ReadOnlyBatchedListTests.cs
@@ -1,0 +1,114 @@
+﻿// Licensed under the Apache 2.0 License. See LICENSE.txt in the project root for more information.
+
+using System;
+using System.Linq;
+using ElasticLinq.Utility;
+using Xunit;
+
+namespace ElasticLinq.Test.Utility
+{
+    public class ReadOnlyBatchedListTests
+    {
+        [Fact]
+        public void Count_ReturnsExptectedCount()
+        {
+            var list = new ReadOnlyBatchedList<int>(Enumerable.Range(0, 100), 16);
+
+            var count = list.Count;
+
+            Assert.Equal(100, count);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(99)]
+        [InlineData(16)]
+        [InlineData(17)]
+        public void Indexer_ReturnsCorrectItem(int index)
+        {
+            var list = new ReadOnlyBatchedList<int>(Enumerable.Range(0, 100), 16);
+
+            var item = list[index];
+
+            Assert.Equal(index, item);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(100)]
+        public void Indexer_ThrowsArgumentOutOfRangeException_WhenIndexIsOutOfRange(int index)
+        {
+            var list = new ReadOnlyBatchedList<int>(Enumerable.Range(0, 100));
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                var temp = list[index];
+            });
+            Assert.Equal("index", exception.ParamName);
+            Assert.Equal(index, exception.ActualValue);
+        }
+
+        [Fact]
+        public void GetEnumerator_EnumeratorIsInitializedToDefaultValue()
+        {
+            var list = new ReadOnlyBatchedList<int>(Enumerable.Range(1, 100), 16);
+
+            var enumerator = list.GetEnumerator();
+
+            Assert.Equal(default(int), enumerator.Current);
+        }
+
+        [Fact]
+        public void GetEnumerator_EnumeratorCanBeAdvancedToFirstElement()
+        {
+            var enumerator = new ReadOnlyBatchedList<int>(Enumerable.Range(1, 100), 16).GetEnumerator();
+
+            var result = enumerator.MoveNext();
+
+            Assert.True(result);
+            Assert.Equal(1, enumerator.Current);
+        }
+
+        [Fact]
+        public void GetEnumerator_AdvancedEnumeratorReturnsSameItem()
+        {
+            var enumerator = new ReadOnlyBatchedList<int>(Enumerable.Range(1, 100), 16).GetEnumerator();
+            enumerator.MoveNext();
+
+            var currentA = enumerator.Current;
+            var currentB = enumerator.Current;
+
+            Assert.Equal(currentA, currentB);
+        }
+
+        [Fact]
+        public void GetEnumerator_CanBeAdvancedToLastItem()
+        {
+            var enumerator = new ReadOnlyBatchedList<int>(Enumerable.Range(1, 100), 16).GetEnumerator();
+            for (int i = 0; i < 99; i++)
+            {
+                enumerator.MoveNext();
+            }
+
+            var result = enumerator.MoveNext();
+            var current = enumerator.Current;
+
+            Assert.Equal(100, current);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void GetEnumerator_EnumeratorAdvancedPastLastItemReturnsFalse()
+        {
+            var enumerator = new ReadOnlyBatchedList<int>(Enumerable.Range(1, 100), 16).GetEnumerator();
+            for (int i = 0; i < 100; i++)
+            {
+                enumerator.MoveNext();
+            }
+
+            var result = enumerator.MoveNext();
+
+            Assert.False(result);
+        }
+    }
+}

--- a/Source/ElasticLINQ/ElasticLINQ.csproj
+++ b/Source/ElasticLINQ/ElasticLINQ.csproj
@@ -142,9 +142,11 @@
     <Compile Include="Test\TestableElasticQueryProvider.cs" />
     <Compile Include="Utility\Argument.cs" />
     <Compile Include="Utility\AsyncHelper.cs" />
+    <Compile Include="Utility\EnumerableExtensions.cs" />
     <Compile Include="Utility\ExpressionExtensions.cs" />
     <Compile Include="Utility\ForcedAuthHandler.cs" />
     <Compile Include="Request\Highlight.cs" />
+    <Compile Include="Utility\ReadOnlyBatchedList.cs" />
     <Compile Include="Utility\TypeHelper.cs" />
     <Compile Include="Mapping\IElasticMapping.cs" />
     <Compile Include="Mapping\TrivialElasticMapping.cs" />

--- a/Source/ElasticLINQ/Response/Materializers/ListHitsElasticMaterializer.cs
+++ b/Source/ElasticLINQ/Response/Materializers/ListHitsElasticMaterializer.cs
@@ -48,9 +48,9 @@ namespace ElasticLinq.Response.Materializers
                 .Invoke(null, new object[] { hits.hits, projector });
         }
 
-        internal static List<T> Many<T>(IEnumerable<Hit> hits, Func<Hit, object> projector)
+        internal static IReadOnlyList<T> Many<T>(IEnumerable<Hit> hits, Func<Hit, object> projector)
         {
-            return hits.Select(projector).Cast<T>().ToList();
+            return hits.Select(projector).Cast<T>().ToReadOnlyBatchedList();
         }
     }
 }

--- a/Source/ElasticLINQ/Utility/EnumerableExtensions.cs
+++ b/Source/ElasticLINQ/Utility/EnumerableExtensions.cs
@@ -1,0 +1,14 @@
+﻿// Licensed under the Apache 2.0 License. See LICENSE.txt in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace ElasticLinq.Utility
+{
+    static class EnumerableExtensions
+    {
+        public static ReadOnlyBatchedList<T> ToReadOnlyBatchedList<T>(this IEnumerable<T> enumerable)
+        {
+            return new ReadOnlyBatchedList<T>(enumerable);
+        }
+    }
+}

--- a/Source/ElasticLINQ/Utility/ReadOnlyBatchedList.cs
+++ b/Source/ElasticLINQ/Utility/ReadOnlyBatchedList.cs
@@ -1,0 +1,120 @@
+﻿// Licensed under the Apache 2.0 License. See LICENSE.txt in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+
+namespace ElasticLinq.Utility
+{
+    [DebuggerDisplay("Count = {Count}")]
+    [DebuggerTypeProxy(typeof(ReadOnlyBatchedList<>.BatchedListDebugView))]
+    internal class ReadOnlyBatchedList<T> : IReadOnlyList<T>
+    {
+        // 8192 * 8-byte (i.e. 64-bit) pointers = 65536 bytes, which is below the 85000 byte large object heap threshold. We could have a higher limit when running in 32-bit processes, but that would complicate the logic
+        static int defaultMaxBatchCapacity = 8192;
+
+        readonly int maxBatchCapacity;
+        readonly IReadOnlyList<IReadOnlyList<T>> batches;
+        readonly int count;
+
+        public ReadOnlyBatchedList(IEnumerable<T> enumerable) : this(enumerable, defaultMaxBatchCapacity)
+        {
+        }
+
+        internal ReadOnlyBatchedList(IEnumerable<T> enumerable, int maxBatchCapacity)
+        {
+            if (enumerable == null)
+                throw new ArgumentNullException(nameof(enumerable));
+            if (maxBatchCapacity < 1)
+                throw new ArgumentOutOfRangeException(nameof(maxBatchCapacity), maxBatchCapacity, "The maximum capacity of a batch must be a positive number.");
+
+            this.maxBatchCapacity = maxBatchCapacity;
+
+            int? totalCount = null;
+            var collection = enumerable as ICollection<T>;
+            if (collection != null)
+                totalCount = collection.Count;
+
+            var batches = new List<IReadOnlyList<T>>();
+
+            int currentTotalCount = 0;
+            List<T> currentBatch = null;
+            foreach (var item in enumerable)
+            {
+                if (currentBatch == null || currentBatch.Count == maxBatchCapacity)
+                {
+                    int capacity = 0;
+                    if (totalCount.HasValue)
+                    {
+                        int remainingCount = totalCount.Value - currentTotalCount;
+                        capacity = Math.Min(remainingCount, maxBatchCapacity);
+                    }
+                    currentBatch = new List<T>(capacity);
+                    batches.Add(currentBatch);
+                }
+
+                currentBatch.Add(item);
+                currentTotalCount++;
+            }
+
+            this.batches = batches;
+            this.count = currentTotalCount;
+        }
+
+        public T this[int index]
+        {
+            get
+            {
+                if (index < 0 || index >= Count)
+                    throw new ArgumentOutOfRangeException(nameof(index), index, "Index was out of range. Must be non-negative and less than the size of the collection.");
+
+                int batchNumber = index / maxBatchCapacity;
+                int batchIndex = index % maxBatchCapacity;
+                return batches[batchNumber][batchIndex];
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                return count;
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            foreach (var batch in batches)
+                foreach (var item in batch)
+                    yield return item;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        private class BatchedListDebugView
+        {
+            readonly ReadOnlyBatchedList<T> list;
+
+            public BatchedListDebugView(ReadOnlyBatchedList<T> list)
+            {
+                this.list = list;
+            }
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public T[] Items
+            {
+                get
+                {
+                    return list.ToArray();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is one of the changes to address issues in https://github.com/CenturyLinkCloud/ElasticLINQ/issues/89
