### PR TITLE
Add support for object initializer syntax

### DIFF
--- a/Source/ElasticLINQ.IntegrationTest/ElasticLINQ.IntegrationTest.csproj
+++ b/Source/ElasticLINQ.IntegrationTest/ElasticLINQ.IntegrationTest.csproj
@@ -76,6 +76,7 @@
     <Compile Include="AsyncTests.cs" />
     <Compile Include="OrderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ProjectionTests.cs" />
     <Compile Include="WhereTests\StringWhereTests.cs" />
     <Compile Include="WhereTests\IntWhereTests.cs" />
     <Compile Include="WhereTests\DateWhereTests.cs" />

--- a/Source/ElasticLINQ.IntegrationTest/Models/WebUser.cs
+++ b/Source/ElasticLINQ.IntegrationTest/Models/WebUser.cs
@@ -38,5 +38,14 @@ namespace ElasticLinq.IntegrationTest.Models
         {
             return Id.GetHashCode();
         }
+
+        public WebUser()
+        {            
+        }
+
+        public WebUser(string phone)
+        {
+            Phone = phone;
+        }
     }
 }

--- a/Source/ElasticLINQ.IntegrationTest/ProjectionTests.cs
+++ b/Source/ElasticLINQ.IntegrationTest/ProjectionTests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Linq;
+using ElasticLinq.IntegrationTest.Models;
+using Xunit;
+
+namespace ElasticLinq.IntegrationTest
+{
+    public class ProjectionTests
+    {
+        [Fact]
+        public void ProjectWithObjectInitializerAndNoContructorArgs()
+        {
+
+            DataAssert.Same<WebUser>(q => q.Select(x => new WebUser { Id = x.Id, Email = x.Forename }));
+        }
+
+        [Fact]
+        public void ProjectWithObjectInitializerAndContructorArgs()
+        {
+            DataAssert.Same<WebUser>(q => q.Select(x => new WebUser(x.PasswordHash) { Surname = x.Email }));
+        }
+
+        [Fact]
+        public void ProjectWithContructorArgsAndNoObjectInitializer()
+        {
+            DataAssert.Same<WebUser>(q => q.Select(x => new WebUser(x.Username)));
+        }
+    }
+}

--- a/Source/ElasticLINQ.Test/Request/Visitors/BranchSelectExpressionVisitorTests.cs
+++ b/Source/ElasticLINQ.Test/Request/Visitors/BranchSelectExpressionVisitorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed under the Apache 2.0 License. See LICENSE.txt in the project root for more information.
 
 using ElasticLinq.Request.Visitors;
+using ElasticLinq.Test.TestSupport;
 using System;
 using System.Linq.Expressions;
 using Xunit;
@@ -29,6 +30,49 @@ namespace ElasticLinq.Test.Request.Visitors
 
             Assert.Single(selectedBranches, s => s.NodeType == ExpressionType.MemberAccess);
             Assert.Equal(1, selectedBranches.Count);
+        }
+
+        [Fact]
+        public void SelectIncludesConstructorWithNoMemberInitBindings()
+        {
+            Expression<Func<int, Robot>> expression = i => new Robot();
+
+            var selectedBranches = BranchSelectExpressionVisitor.Select(expression, e => e.NodeType != ExpressionType.Parameter);
+
+            Assert.Single(selectedBranches, s => s.NodeType == ExpressionType.New);
+            Assert.Equal(1, selectedBranches.Count);
+        }
+
+        [Fact]
+        public void SelectDoesNotIncludeMemberInitBranchesWhenTheyHaveNoIncludedBindings()
+        {
+            Expression<Func<int, Robot>> expression = i => new Robot { Id = i };
+
+            var selectedBranches = BranchSelectExpressionVisitor.Select(expression, e => e.NodeType != ExpressionType.Parameter);
+
+            Assert.Empty(selectedBranches);
+        }
+
+        [Fact]
+        public void SelectDoesNotIncludeMemberInitBranchesWhenTheyPartiallyIncludedBindings()
+        {
+            Expression<Func<int, Robot>> expression = i => new Robot { Id = i, Name = "Hudzen-10" };
+
+            var selectedBranches = BranchSelectExpressionVisitor.Select(expression, e => e.NodeType != ExpressionType.Parameter);
+
+            Assert.Single(selectedBranches, s => s.NodeType == ExpressionType.Constant);
+            Assert.Equal(1, selectedBranches.Count);
+        }
+
+        [Fact]
+        public void SelectIncludeMemberInitBranchesWithAllBindings()
+        {
+            Expression<Func<int, Robot>> expression = i => new Robot { Id = 10, Name = "Hudzen-10" };
+
+            var selectedBranches = BranchSelectExpressionVisitor.Select(expression, e => e.NodeType != ExpressionType.Parameter);
+
+            Assert.Single(selectedBranches, s => s.NodeType == ExpressionType.MemberInit);
+            Assert.Equal(3, selectedBranches.Count);
         }
     }
 }

--- a/Source/ElasticLINQ/Request/Visitors/BranchSelectExpressionVisitor.cs
+++ b/Source/ElasticLINQ/Request/Visitors/BranchSelectExpressionVisitor.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 
 namespace ElasticLinq.Request.Visitors
@@ -26,6 +27,20 @@ namespace ElasticLinq.Request.Visitors
             var visitor = new BranchSelectExpressionVisitor(predicate);
             visitor.Visit(e);
             return visitor.matches;
+        }
+
+        protected override Expression VisitMemberInit(MemberInitExpression node)
+        {
+            Visit(node.NewExpression);
+            Visit(node.Bindings, VisitMemberBinding);
+
+            if (matches.Contains(node.NewExpression) && node.Bindings.Count > 0)
+            {
+                // We should never consider the newExpression in isolation from the bindings
+                matches.Remove(node.NewExpression);
+            }
+
+            return node;
         }
 
         public override Expression Visit(Expression node)

--- a/Source/ElasticLINQ/Request/Visitors/ElasticQueryTranslator.cs
+++ b/Source/ElasticLINQ/Request/Visitors/ElasticQueryTranslator.cs
@@ -391,6 +391,9 @@ namespace ElasticLinq.Request.Visitors
             if (selectBody is MethodCallExpression)
                 RebindSelectBody(selectBody, ((MethodCallExpression)selectBody).Arguments, lambda.Parameters);
 
+            if (selectBody is MemberInitExpression)
+                RebindPropertiesAndElasticFields(selectBody);
+
             finalItemType = selectBody.Type;
 
             return Visit(source);


### PR DESCRIPTION
Allows syntax in the Select body where you use the object initializer syntax, e.g.

```csharp
db.Query<WebUser>().Select(w => new WebUser2 { Id = w.id, Email = w.Email });
```