### PR TITLE
ignore_unmapped=true changed to unmapped_type=long

### DIFF
--- a/Source/ElasticLINQ.Test/Request/Formatters/SearchRequestFormatterTests.cs
+++ b/Source/ElasticLINQ.Test/Request/Formatters/SearchRequestFormatterTests.cs
@@ -103,7 +103,7 @@ namespace ElasticLinq.Test.Request.Formatters
                     var first = (JProperty)actualSort.First;
                     Assert.Equal(desiredSort.Name, first.Name);
                     var childProperties = first.First.Children().Cast<JProperty>().ToArray();
-                    Assert.Single(childProperties, f => f.Name == "ignore_unmapped" && f.Value.ToObject<bool>());
+                    Assert.Single(childProperties, f => f.Name == "unmapped_type" && f.Value.ToObject<string>() == "long");
                     Assert.Single(childProperties, f => f.Name == "order" && f.Value.ToObject<string>() == "desc");
                 }
                 else

--- a/Source/ElasticLINQ/Request/Formatters/SearchRequestFormatter.cs
+++ b/Source/ElasticLINQ/Request/Formatters/SearchRequestFormatter.cs
@@ -176,7 +176,7 @@ namespace ElasticLinq.Request.Formatters
                     ? (object)sortOption.Name
                     : new JObject(new JProperty(sortOption.Name, "desc"));
 
-            var properties = new List<JProperty> { new JProperty("ignore_unmapped", true) };
+            var properties = new List<JProperty> { new JProperty("unmapped_type", "long") };
             if (!sortOption.Ascending)
                 properties.Add(new JProperty("order", "desc"));
 


### PR DESCRIPTION
Starting from version 1.4 "ignore_unmapped"=true changed to "unmapped_type"="long"

see: https://www.elastic.co/guide/en/elasticsearch/reference/1.4/search-request-sort.html#_ignoring_unmapped_fields