### PR TITLE
Code cleanup

### DIFF
--- a/Source/ElasticLINQ/Async/AsyncQueryable.Average.cs
+++ b/Source/ElasticLINQ/Async/AsyncQueryable.Average.cs
@@ -47,7 +47,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<double> AverageAsync(this IQueryable<int> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, averageIntMethodInfo.Value), cancellationToken);
+            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, averageIntMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> is null.</exception>
         public static async Task<double?> AverageAsync(this IQueryable<int?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (double?)await ExecuteAsync(source.Provider, FinalExpression(source, averageIntNullableMethodInfo.Value), cancellationToken);
+            return (double?)await ExecuteAsync(source.Provider, FinalExpression(source, averageIntNullableMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<double> AverageAsync(this IQueryable<long> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, averageLongMethodInfo.Value), cancellationToken);
+            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, averageLongMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> is null.</exception>
         public static async Task<double?> AverageAsync(this IQueryable<long?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, averageLongNullableMethodInfo.Value), cancellationToken);
+            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, averageLongNullableMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<float> AverageAsync(this IQueryable<float> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (float)await ExecuteAsync(source.Provider, FinalExpression(source, averageFloatMethodInfo.Value), cancellationToken);
+            return (float)await ExecuteAsync(source.Provider, FinalExpression(source, averageFloatMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> is null.</exception>
         public static async Task<float?> AverageAsync(this IQueryable<float?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (float?)await ExecuteAsync(source.Provider, FinalExpression(source, averageFloatNullableMethodInfo.Value), cancellationToken);
+            return (float?)await ExecuteAsync(source.Provider, FinalExpression(source, averageFloatNullableMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<double> AverageAsync(this IQueryable<double> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, averageDoubleMethodInfo.Value), cancellationToken);
+            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, averageDoubleMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> is null.</exception>
         public static async Task<double?> AverageAsync(this IQueryable<double?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (double?)await ExecuteAsync(source.Provider, FinalExpression(source, averageDoubleNullableMethodInfo.Value), cancellationToken);
+            return (double?)await ExecuteAsync(source.Provider, FinalExpression(source, averageDoubleNullableMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -175,7 +175,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<decimal> AverageAsync(this IQueryable<decimal> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (decimal)await ExecuteAsync(source.Provider, FinalExpression(source, averageDecimalMethodInfo.Value), cancellationToken);
+            return (decimal)await ExecuteAsync(source.Provider, FinalExpression(source, averageDecimalMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -190,7 +190,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> is null.</exception>
         public static async Task<decimal?> AverageAsync(this IQueryable<decimal?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (decimal?)await ExecuteAsync(source.Provider, FinalExpression(source, averageDecimalNullableMethodInfo.Value), cancellationToken);
+            return (decimal?)await ExecuteAsync(source.Provider, FinalExpression(source, averageDecimalNullableMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -209,7 +209,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<double> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, averageIntSelectorMethodInfo.Value, selector), cancellationToken);
+            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, averageIntSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -226,7 +226,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<double?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (double?)await ExecuteAsync(source.Provider, FinalExpression(source, averageIntNullableSelectorMethodInfo.Value, selector), cancellationToken);
+            return (double?)await ExecuteAsync(source.Provider, FinalExpression(source, averageIntNullableSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -245,7 +245,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<float> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (float)await ExecuteAsync(source.Provider, FinalExpression(source, averageFloatSelectorMethodInfo.Value, selector), cancellationToken);
+            return (float)await ExecuteAsync(source.Provider, FinalExpression(source, averageFloatSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -262,7 +262,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<float?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (float?)await ExecuteAsync(source.Provider, FinalExpression(source, averageFloatNullableSelectorMethodInfo.Value, selector), cancellationToken);
+            return (float?)await ExecuteAsync(source.Provider, FinalExpression(source, averageFloatNullableSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -281,7 +281,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<double> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, averageLongSelectorMethodInfo.Value, selector), cancellationToken);
+            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, averageLongSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -298,7 +298,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<double?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (double?)await ExecuteAsync(source.Provider, FinalExpression(source, averageLongNullableSelectorMethodInfo.Value, selector), cancellationToken);
+            return (double?)await ExecuteAsync(source.Provider, FinalExpression(source, averageLongNullableSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -317,7 +317,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<double> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, averageDoubleSelectorMethodInfo.Value, selector), cancellationToken);
+            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, averageDoubleSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -334,7 +334,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<double?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (double?)await ExecuteAsync(source.Provider, FinalExpression(source, averageDoubleNullableSelectorMethodInfo.Value, selector), cancellationToken);
+            return (double?)await ExecuteAsync(source.Provider, FinalExpression(source, averageDoubleNullableSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -353,7 +353,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<decimal> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (decimal)await ExecuteAsync(source.Provider, FinalExpression(source, averageDecimalSelectorMethodInfo.Value, selector), cancellationToken);
+            return (decimal)await ExecuteAsync(source.Provider, FinalExpression(source, averageDecimalSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -370,7 +370,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<decimal?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (decimal)await ExecuteAsync(source.Provider, FinalExpression(source, averageDecimalNullableSelectorMethodInfo.Value, selector), cancellationToken);
+            return (decimal)await ExecuteAsync(source.Provider, FinalExpression(source, averageDecimalNullableSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/Source/ElasticLINQ/Async/AsyncQueryable.Average.cs
+++ b/Source/ElasticLINQ/Async/AsyncQueryable.Average.cs
@@ -34,16 +34,16 @@ namespace ElasticLinq.Async
         static readonly Lazy<MethodInfo> averageDecimalNullableSelectorMethodInfo = QueryableMethodBySelectorParameterType("Average", 2, typeof(decimal?));
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of <see cref="T:System.Int32"/> values.
+        /// Asynchronously computes the average of a sequence of <see cref="Int32"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values.
         /// </returns>
-        /// <param name="source">A sequence of <see cref="T:System.Int32"/> values to calculate the average of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of <see cref="Int32"/> values to calculate the average of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<double> AverageAsync(this IQueryable<int> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -51,14 +51,14 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of nullable <see cref="T:System.Int32"/> values.
+        /// Asynchronously computes the average of a sequence of nullable <see cref="Int32"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values, or null if the source sequence is empty or contains only null values.
         /// </returns>
-        /// <param name="source">A sequence of nullable <see cref="T:System.Int32"/> values to calculate the average of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of nullable <see cref="Int32"/> values to calculate the average of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
         public static async Task<double?> AverageAsync(this IQueryable<int?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -66,16 +66,16 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of <see cref="T:System.Int64"/> values.
+        /// Asynchronously computes the average of a sequence of <see cref="Int64"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values.
         /// </returns>
-        /// <param name="source">A sequence of <see cref="T:System.Int64"/> values to calculate the average of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of <see cref="Int64"/> values to calculate the average of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<double> AverageAsync(this IQueryable<long> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -83,14 +83,14 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of nullable <see cref="T:System.Int64"/> values.
+        /// Asynchronously computes the average of a sequence of nullable <see cref="Int64"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values, or null if the source sequence is empty or contains only null values.
         /// </returns>
-        /// <param name="source">A sequence of nullable <see cref="T:System.Int64"/> values to calculate the average of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of nullable <see cref="Int64"/> values to calculate the average of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
         public static async Task<double?> AverageAsync(this IQueryable<long?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -98,16 +98,16 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of <see cref="T:System.Single"/> values.
+        /// Asynchronously computes the average of a sequence of <see cref="Single"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values.
         /// </returns>
-        /// <param name="source">A sequence of <see cref="T:System.Single"/> values to calculate the average of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of <see cref="Single"/> values to calculate the average of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<float> AverageAsync(this IQueryable<float> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -115,14 +115,14 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of nullable <see cref="T:System.Single"/> values.
+        /// Asynchronously computes the average of a sequence of nullable <see cref="Single"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values, or null if the source sequence is empty or contains only null values.
         /// </returns>
-        /// <param name="source">A sequence of nullable <see cref="T:System.Single"/> values to calculate the average of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of nullable <see cref="Single"/> values to calculate the average of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
         public static async Task<float?> AverageAsync(this IQueryable<float?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -130,16 +130,16 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of <see cref="T:System.Double"/> values.
+        /// Asynchronously computes the average of a sequence of <see cref="Double"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values.
         /// </returns>
-        /// <param name="source">A sequence of <see cref="T:System.Double"/> values to calculate the average of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of <see cref="Double"/> values to calculate the average of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<double> AverageAsync(this IQueryable<double> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -147,14 +147,14 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of nullable <see cref="T:System.Double"/> values.
+        /// Asynchronously computes the average of a sequence of nullable <see cref="Double"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values, or null if the source sequence is empty or contains only null values.
         /// </returns>
-        /// <param name="source">A sequence of nullable <see cref="T:System.Double"/> values to calculate the average of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of nullable <see cref="Double"/> values to calculate the average of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
         public static async Task<double?> AverageAsync(this IQueryable<double?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -162,16 +162,16 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of <see cref="T:System.Decimal"/> values.
+        /// Asynchronously computes the average of a sequence of <see cref="Decimal"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values.
         /// </returns>
-        /// <param name="source">A sequence of <see cref="T:System.Decimal"/> values to calculate the average of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of <see cref="Decimal"/> values to calculate the average of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<decimal> AverageAsync(this IQueryable<decimal> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -179,14 +179,14 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of nullable <see cref="T:System.Decimal"/> values.
+        /// Asynchronously computes the average of a sequence of nullable <see cref="Decimal"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values, or null if the source sequence is empty or contains only null values.
         /// </returns>
-        /// <param name="source">A sequence of nullable <see cref="T:System.Decimal"/> values to calculate the average of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of nullable <see cref="Decimal"/> values to calculate the average of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
         public static async Task<decimal?> AverageAsync(this IQueryable<decimal?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -194,18 +194,18 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of <see cref="T:System.Int32"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the average of a sequence of <see cref="Int32"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values.
         /// </returns>
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<double> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -213,16 +213,16 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of nullable <see cref="T:System.Int32"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the average of a sequence of nullable <see cref="Int32"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values, or null if the <paramref name="source"/> sequence is empty or contains only null values.
         /// </returns>
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<double?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -230,18 +230,18 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of <see cref="T:System.Single"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the average of a sequence of <see cref="Single"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values.
         /// </returns>
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<float> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -249,16 +249,16 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of nullable <see cref="T:System.Single"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the average of a sequence of nullable <see cref="Single"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values, or null if the <paramref name="source"/> sequence is empty or contains only null values.
         /// </returns>
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<float?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -266,18 +266,18 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of <see cref="T:System.Int64"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the average of a sequence of <see cref="Int64"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values.
         /// </returns>
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<double> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -285,16 +285,16 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of nullable <see cref="T:System.Int64"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the average of a sequence of nullable <see cref="Int64"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values, or null if the <paramref name="source"/> sequence is empty or contains only null values.
         /// </returns>
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<double?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -302,18 +302,18 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of <see cref="T:System.Double"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the average of a sequence of <see cref="Double"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values.
         /// </returns>
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<double> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -321,16 +321,16 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of nullable <see cref="T:System.Double"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the average of a sequence of nullable <see cref="Double"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values, or null if the <paramref name="source"/> sequence is empty or contains only null values.
         /// </returns>
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<double?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -338,18 +338,18 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of <see cref="T:System.Decimal"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the average of a sequence of <see cref="Decimal"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values.
         /// </returns>
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// <paramref name="source"/> contains no elements.</exception>
         public static async Task<decimal> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -357,16 +357,16 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the average of a sequence of nullable <see cref="T:System.Decimal"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the average of a sequence of nullable <see cref="Decimal"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the average of the sequence of values, or null if the <paramref name="source"/> sequence is empty or contains only null values.
         /// </returns>
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<decimal?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/Source/ElasticLINQ/Async/AsyncQueryable.Entity.cs
+++ b/Source/ElasticLINQ/Async/AsyncQueryable.Entity.cs
@@ -27,12 +27,12 @@ namespace ElasticLinq.Async
         /// <returns>
         /// A task that returns the first element in <paramref name="source"/>.
         /// </returns>
-        /// <param name="source">The <see cref="T:System.Linq.IQueryable`1"/> to return the first element of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="source">The <see cref="IQueryable{T}"/> to return the first element of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The source sequence is empty.</exception>
+        /// <exception cref="InvalidOperationException">The source sequence is empty.</exception>
         public static async Task<TSource> FirstAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, firstMethodInfo.Value), cancellationToken);
@@ -44,13 +44,13 @@ namespace ElasticLinq.Async
         /// <returns>
         /// A task that returns the first element in <paramref name="source"/> that passes the test in <paramref name="predicate"/>.
         /// </returns>
-        /// <param name="source">An <see cref="T:System.Linq.IQueryable`1"/> to return an element from.</param>
+        /// <param name="source">An <see cref="IQueryable{T}"/> to return an element from.</param>
         /// <param name="predicate">A function to test each element for a condition.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">No element satisfies the condition in <paramref name="predicate"/>.-or-The source sequence is empty.</exception>
+        /// <exception cref="InvalidOperationException">No element satisfies the condition in <paramref name="predicate"/>.-or-The source sequence is empty.</exception>
         public static async Task<TSource> FirstAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, firstPredicateMethodInfo.Value, predicate), cancellationToken);
@@ -62,10 +62,10 @@ namespace ElasticLinq.Async
         /// <returns>
         /// A task that returns default(<typeparamref name="TSource"/>) if <paramref name="source"/> is empty; otherwise, the first element in <paramref name="source"/>.
         /// </returns>
-        /// <param name="source">The <see cref="T:System.Linq.IQueryable`1"/> to return the first element of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="source">The <see cref="IQueryable{T}"/> to return the first element of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
         public static async Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -78,11 +78,11 @@ namespace ElasticLinq.Async
         /// <returns>
         /// A task that returns default(<typeparamref name="TSource"/>) if <paramref name="source"/> is empty or if no element passes the test specified by <paramref name="predicate"/>; otherwise, the first element in <paramref name="source"/> that passes the test specified by <paramref name="predicate"/>.
         /// </returns>
-        /// <param name="source">An <see cref="T:System.Linq.IQueryable`1"/> to return an element from.</param>
+        /// <param name="source">An <see cref="IQueryable{T}"/> to return an element from.</param>
         /// <param name="predicate">A function to test each element for a condition.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         public static async Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -95,12 +95,12 @@ namespace ElasticLinq.Async
         /// <returns>
         /// A task that returns the single element of the input sequence.
         /// </returns>
-        /// <param name="source">An <see cref="T:System.Linq.IQueryable`1"/> to return the single element of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="source">An <see cref="IQueryable{T}"/> to return the single element of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// <paramref name="source"/> has more than one element.</exception>
         public static async Task<TSource> SingleAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -113,13 +113,13 @@ namespace ElasticLinq.Async
         /// <returns>
         /// A task that returns the single element of the input sequence that satisfies the condition in <paramref name="predicate"/>.
         /// </returns>
-        /// <param name="source">An <see cref="T:System.Linq.IQueryable`1"/> to return a single element from.</param>
+        /// <param name="source">An <see cref="IQueryable{T}"/> to return a single element from.</param>
         /// <param name="predicate">A function to test an element for a condition.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">No element satisfies the condition in <paramref name="predicate"/>.-or-More than one element satisfies the condition in <paramref name="predicate"/>.-or-The source sequence is empty.</exception>
+        /// <exception cref="InvalidOperationException">No element satisfies the condition in <paramref name="predicate"/>.-or-More than one element satisfies the condition in <paramref name="predicate"/>.-or-The source sequence is empty.</exception>
         public static async Task<TSource> SingleAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, singlePredicateMethodInfo.Value, predicate), cancellationToken);
@@ -131,12 +131,12 @@ namespace ElasticLinq.Async
         /// <returns>
         /// A task that returns the single element of the input sequence, or default(<typeparamref name="TSource"/>) if the sequence contains no elements.
         /// </returns>
-        /// <param name="source">An <see cref="T:System.Linq.IQueryable`1"/> to return the single element of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="source">An <see cref="IQueryable{T}"/> to return the single element of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// <paramref name="source"/> has more than one element.</exception>
         public static async Task<TSource> SingleOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -149,13 +149,13 @@ namespace ElasticLinq.Async
         /// <returns>
         /// A task that returns the single element of the input sequence that satisfies the condition in <paramref name="predicate"/>, or default(<typeparamref name="TSource"/>) if no such element is found.
         /// </returns>
-        /// <param name="source">An <see cref="T:System.Linq.IQueryable`1"/> to return a single element from.</param>
+        /// <param name="source">An <see cref="IQueryable{T}"/> to return a single element from.</param>
         /// <param name="predicate">A function to test an element for a condition.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">More than one element satisfies the condition in <paramref name="predicate"/>.</exception>
+        /// <exception cref="InvalidOperationException">More than one element satisfies the condition in <paramref name="predicate"/>.</exception>
         public static async Task<TSource> SingleOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, singleOrDefaultPredicateMethodInfo.Value, predicate), cancellationToken);

--- a/Source/ElasticLINQ/Async/AsyncQueryable.Entity.cs
+++ b/Source/ElasticLINQ/Async/AsyncQueryable.Entity.cs
@@ -35,7 +35,7 @@ namespace ElasticLinq.Async
         /// <exception cref="InvalidOperationException">The source sequence is empty.</exception>
         public static async Task<TSource> FirstAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, firstMethodInfo.Value), cancellationToken);
+            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, firstMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace ElasticLinq.Async
         /// <exception cref="InvalidOperationException">No element satisfies the condition in <paramref name="predicate"/>.-or-The source sequence is empty.</exception>
         public static async Task<TSource> FirstAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, firstPredicateMethodInfo.Value, predicate), cancellationToken);
+            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, firstPredicateMethodInfo.Value, predicate), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> is null.</exception>
         public static async Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, firstOrDefaultMethodInfo.Value), cancellationToken);
+            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, firstOrDefaultMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         public static async Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, firstOrDefaultPredicateMethodInfo.Value, predicate), cancellationToken);
+            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, firstOrDefaultPredicateMethodInfo.Value, predicate), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> has more than one element.</exception>
         public static async Task<TSource> SingleAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, singleMethodInfo.Value), cancellationToken);
+            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, singleMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace ElasticLinq.Async
         /// <exception cref="InvalidOperationException">No element satisfies the condition in <paramref name="predicate"/>.-or-More than one element satisfies the condition in <paramref name="predicate"/>.-or-The source sequence is empty.</exception>
         public static async Task<TSource> SingleAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, singlePredicateMethodInfo.Value, predicate), cancellationToken);
+            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, singlePredicateMethodInfo.Value, predicate), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> has more than one element.</exception>
         public static async Task<TSource> SingleOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, singleOrDefaultMethodInfo.Value), cancellationToken);
+            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, singleOrDefaultMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace ElasticLinq.Async
         /// <exception cref="InvalidOperationException">More than one element satisfies the condition in <paramref name="predicate"/>.</exception>
         public static async Task<TSource> SingleOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, singleOrDefaultPredicateMethodInfo.Value, predicate), cancellationToken);
+            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, singleOrDefaultPredicateMethodInfo.Value, predicate), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/Source/ElasticLINQ/Async/AsyncQueryable.Sum.cs
+++ b/Source/ElasticLINQ/Async/AsyncQueryable.Sum.cs
@@ -34,78 +34,78 @@ namespace ElasticLinq.Async
         static readonly Lazy<MethodInfo> sumDecimalNullableSelectorMethodInfo = QueryableMethodByReturnType("Sum", 2, typeof(decimal?));
 
         /// <summary>
-        /// Asynchronously computes the sum of a sequence of <see cref="T:System.Int32"/> values.
+        /// Asynchronously computes the sum of a sequence of <see cref="Int32"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the values in the sequence.
         /// </returns>
-        /// <param name="source">A sequence of <see cref="T:System.Int32"/> values to calculate the sum of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of <see cref="Int32"/> values to calculate the sum of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The sum is larger than <see cref="F:System.Int32.MaxValue"/>.</exception>
+        /// <exception cref="OverflowException">The sum is larger than <see cref="Int32.MaxValue"/>.</exception>
         public static async Task<int> SumAsync(this IQueryable<int> source, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (int)await ExecuteAsync(source.Provider, FinalExpression(source, sumIntMethodInfo.Value), cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of a sequence of nullable <see cref="T:System.Int32"/> values.
+        /// Asynchronously computes the sum of a sequence of nullable <see cref="Int32"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the values in the sequence.
         /// </returns>
-        /// <param name="source">A sequence of nullable <see cref="T:System.Int32"/> values to calculate the sum of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of nullable <see cref="Int32"/> values to calculate the sum of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The sum is larger than <see cref="F:System.Int32.MaxValue"/>.</exception>
+        /// <exception cref="OverflowException">The sum is larger than <see cref="Int32.MaxValue"/>.</exception>
         public static async Task<int?> SumAsync(this IQueryable<int?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (int)await ExecuteAsync(source.Provider, FinalExpression(source, sumIntNullableMethodInfo.Value), cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of a sequence of <see cref="T:System.Int64"/> values.
+        /// Asynchronously computes the sum of a sequence of <see cref="Int64"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the values in the sequence.
         /// </returns>
-        /// <param name="source">A sequence of <see cref="T:System.Int64"/> values to calculate the sum of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of <see cref="Int64"/> values to calculate the sum of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The sum is larger than <see cref="F:System.Int64.MaxValue"/>.</exception>
+        /// <exception cref="OverflowException">The sum is larger than <see cref="Int64.MaxValue"/>.</exception>
         public static async Task<long> SumAsync(this IQueryable<long> source, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (long)await ExecuteAsync(source.Provider, FinalExpression(source, sumLongMethodInfo.Value), cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of a sequence of nullable <see cref="T:System.Int64"/> values.
+        /// Asynchronously computes the sum of a sequence of nullable <see cref="Int64"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the values in the sequence.
         /// </returns>
-        /// <param name="source">A sequence of nullable <see cref="T:System.Int64"/> values to calculate the sum of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of nullable <see cref="Int64"/> values to calculate the sum of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The sum is larger than <see cref="F:System.Int64.MaxValue"/>.</exception>
+        /// <exception cref="OverflowException">The sum is larger than <see cref="Int64.MaxValue"/>.</exception>
         public static async Task<long?> SumAsync(this IQueryable<long?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (long?)await ExecuteAsync(source.Provider, FinalExpression(source, sumLongNullableMethodInfo.Value), cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of a sequence of <see cref="T:System.Single"/> values.
+        /// Asynchronously computes the sum of a sequence of <see cref="Single"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the values in the sequence.
         /// </returns>
-        /// <param name="source">A sequence of <see cref="T:System.Single"/> values to calculate the sum of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of <see cref="Single"/> values to calculate the sum of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
         public static async Task<float> SumAsync(this IQueryable<float> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -113,14 +113,14 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of a sequence of nullable <see cref="T:System.Single"/> values.
+        /// Asynchronously computes the sum of a sequence of nullable <see cref="Single"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the values in the sequence.
         /// </returns>
-        /// <param name="source">A sequence of nullable <see cref="T:System.Single"/> values to calculate the sum of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of nullable <see cref="Single"/> values to calculate the sum of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
         public static async Task<float?> SumAsync(this IQueryable<float?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -128,14 +128,14 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of a sequence of <see cref="T:System.Double"/> values.
+        /// Asynchronously computes the sum of a sequence of <see cref="Double"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the values in the sequence.
         /// </returns>
-        /// <param name="source">A sequence of <see cref="T:System.Double"/> values to calculate the sum of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of <see cref="Double"/> values to calculate the sum of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
         public static async Task<double> SumAsync(this IQueryable<double> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -143,14 +143,14 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of a sequence of nullable <see cref="T:System.Double"/> values.
+        /// Asynchronously computes the sum of a sequence of nullable <see cref="Double"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the values in the sequence.
         /// </returns>
-        /// <param name="source">A sequence of nullable <see cref="T:System.Double"/> values to calculate the sum of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of nullable <see cref="Double"/> values to calculate the sum of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
         public static async Task<double?> SumAsync(this IQueryable<double?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -158,120 +158,120 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of a sequence of <see cref="T:System.Decimal"/> values.
+        /// Asynchronously computes the sum of a sequence of <see cref="Decimal"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the values in the sequence.
         /// </returns>
-        /// <param name="source">A sequence of <see cref="T:System.Decimal"/> values to calculate the sum of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of <see cref="Decimal"/> values to calculate the sum of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The sum is larger than <see cref="F:System.Decimal.MaxValue"/>.</exception>
+        /// <exception cref="OverflowException">The sum is larger than <see cref="Decimal.MaxValue"/>.</exception>
         public static async Task<decimal> SumAsync(this IQueryable<decimal> source, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (decimal)await ExecuteAsync(source.Provider, FinalExpression(source, sumDecimalMethodInfo.Value), cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of a sequence of nullable <see cref="T:System.Decimal"/> values.
+        /// Asynchronously computes the sum of a sequence of nullable <see cref="Decimal"/> values.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the values in the sequence.
         /// </returns>
-        /// <param name="source">A sequence of nullable <see cref="T:System.Decimal"/> values to calculate the sum of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <param name="source">A sequence of nullable <see cref="Decimal"/> values to calculate the sum of.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The sum is larger than <see cref="F:System.Decimal.MaxValue"/>.</exception>
+        /// <exception cref="OverflowException">The sum is larger than <see cref="Decimal.MaxValue"/>.</exception>
         public static async Task<decimal?> SumAsync(this IQueryable<decimal?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (decimal?)await ExecuteAsync(source.Provider, FinalExpression(source, sumDecimalNullableMethodInfo.Value), cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of the sequence of <see cref="T:System.Int32"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the sum of the sequence of <see cref="Int32"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the projected values.
         /// </returns>
         /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The sum is larger than <see cref="F:System.Int32.MaxValue"/>.</exception>
+        /// <exception cref="OverflowException">The sum is larger than <see cref="Int32.MaxValue"/>.</exception>
         public static async Task<int> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (int)await ExecuteAsync(source.Provider, FinalExpression(source, sumIntSelectorMethodInfo.Value, selector), cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of the sequence of nullable <see cref="T:System.Int32"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the sum of the sequence of nullable <see cref="Int32"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the projected values.
         /// </returns>
         /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The sum is larger than <see cref="F:System.Int32.MaxValue"/>.</exception>
+        /// <exception cref="OverflowException">The sum is larger than <see cref="Int32.MaxValue"/>.</exception>
         public static async Task<int?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (int?)await ExecuteAsync(source.Provider, FinalExpression(source, sumIntNullableSelectorMethodInfo.Value, selector), cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of the sequence of <see cref="T:System.Int64"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the sum of the sequence of <see cref="Int64"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the projected values.
         /// </returns>
         /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The sum is larger than <see cref="F:System.Int64.MaxValue"/>.</exception>
+        /// <exception cref="OverflowException">The sum is larger than <see cref="Int64.MaxValue"/>.</exception>
         public static async Task<long> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (long)await ExecuteAsync(source.Provider, FinalExpression(source, sumLongSelectorMethodInfo.Value, selector), cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of the sequence of nullable <see cref="T:System.Int64"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the sum of the sequence of nullable <see cref="Int64"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the projected values.
         /// </returns>
         /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The sum is larger than <see cref="F:System.Int64.MaxValue"/>.</exception>
+        /// <exception cref="OverflowException">The sum is larger than <see cref="Int64.MaxValue"/>.</exception>
         public static async Task<long?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (long?)await ExecuteAsync(source.Provider, FinalExpression(source, sumLongNullableSelectorMethodInfo.Value, selector), cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of the sequence of <see cref="T:System.Single"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the sum of the sequence of <see cref="Single"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the projected values.
         /// </returns>
         /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<float> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -279,16 +279,16 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of the sequence of nullable <see cref="T:System.Single"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the sum of the sequence of nullable <see cref="Single"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the projected values.
         /// </returns>
         /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<float?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -296,16 +296,16 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of the sequence of <see cref="T:System.Double"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the sum of the sequence of <see cref="Double"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the projected values.
         /// </returns>
         /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<double> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -313,16 +313,16 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of the sequence of nullable <see cref="T:System.Double"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the sum of the sequence of nullable <see cref="Double"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the projected values.
         /// </returns>
         /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<double?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -330,36 +330,36 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of the sequence of <see cref="T:System.Decimal"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the sum of the sequence of <see cref="Decimal"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the projected values.
         /// </returns>
         /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The sum is larger than <see cref="F:System.Decimal.MaxValue"/>.</exception>
+        /// <exception cref="OverflowException">The sum is larger than <see cref="Decimal.MaxValue"/>.</exception>
         public static async Task<decimal> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (decimal)await ExecuteAsync(source.Provider, FinalExpression(source, sumDecimalSelectorMethodInfo.Value, selector), cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously computes the sum of the sequence of nullable <see cref="T:System.Decimal"/> values that is obtained by invoking a projection function on each element of the input sequence.
+        /// Asynchronously computes the sum of the sequence of nullable <see cref="Decimal"/> values that is obtained by invoking a projection function on each element of the input sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the sum of the projected values.
         /// </returns>
         /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The sum is larger than <see cref="F:System.Decimal.MaxValue"/>.</exception>
+        /// <exception cref="OverflowException">The sum is larger than <see cref="Decimal.MaxValue"/>.</exception>
         public static async Task<decimal?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (decimal?)await ExecuteAsync(source.Provider, FinalExpression(source, sumDecimalNullableSelectorMethodInfo.Value, selector), cancellationToken);

--- a/Source/ElasticLINQ/Async/AsyncQueryable.Sum.cs
+++ b/Source/ElasticLINQ/Async/AsyncQueryable.Sum.cs
@@ -46,7 +46,7 @@ namespace ElasticLinq.Async
         /// <exception cref="OverflowException">The sum is larger than <see cref="Int32.MaxValue"/>.</exception>
         public static async Task<int> SumAsync(this IQueryable<int> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (int)await ExecuteAsync(source.Provider, FinalExpression(source, sumIntMethodInfo.Value), cancellationToken);
+            return (int)await ExecuteAsync(source.Provider, FinalExpression(source, sumIntMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace ElasticLinq.Async
         /// <exception cref="OverflowException">The sum is larger than <see cref="Int32.MaxValue"/>.</exception>
         public static async Task<int?> SumAsync(this IQueryable<int?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (int)await ExecuteAsync(source.Provider, FinalExpression(source, sumIntNullableMethodInfo.Value), cancellationToken);
+            return (int)await ExecuteAsync(source.Provider, FinalExpression(source, sumIntNullableMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace ElasticLinq.Async
         /// <exception cref="OverflowException">The sum is larger than <see cref="Int64.MaxValue"/>.</exception>
         public static async Task<long> SumAsync(this IQueryable<long> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (long)await ExecuteAsync(source.Provider, FinalExpression(source, sumLongMethodInfo.Value), cancellationToken);
+            return (long)await ExecuteAsync(source.Provider, FinalExpression(source, sumLongMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace ElasticLinq.Async
         /// <exception cref="OverflowException">The sum is larger than <see cref="Int64.MaxValue"/>.</exception>
         public static async Task<long?> SumAsync(this IQueryable<long?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (long?)await ExecuteAsync(source.Provider, FinalExpression(source, sumLongNullableMethodInfo.Value), cancellationToken);
+            return (long?)await ExecuteAsync(source.Provider, FinalExpression(source, sumLongNullableMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> is null.</exception>
         public static async Task<float> SumAsync(this IQueryable<float> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (float)await ExecuteAsync(source.Provider, FinalExpression(source, sumFloatMethodInfo.Value), cancellationToken);
+            return (float)await ExecuteAsync(source.Provider, FinalExpression(source, sumFloatMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> is null.</exception>
         public static async Task<float?> SumAsync(this IQueryable<float?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (float?)await ExecuteAsync(source.Provider, FinalExpression(source, sumFloatNullableMethodInfo.Value), cancellationToken);
+            return (float?)await ExecuteAsync(source.Provider, FinalExpression(source, sumFloatNullableMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> is null.</exception>
         public static async Task<double> SumAsync(this IQueryable<double> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, sumDoubleMethodInfo.Value), cancellationToken);
+            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, sumDoubleMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> is null.</exception>
         public static async Task<double?> SumAsync(this IQueryable<double?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (double?)await ExecuteAsync(source.Provider, FinalExpression(source, sumDoubleNullableMethodInfo.Value), cancellationToken);
+            return (double?)await ExecuteAsync(source.Provider, FinalExpression(source, sumDoubleNullableMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -170,7 +170,7 @@ namespace ElasticLinq.Async
         /// <exception cref="OverflowException">The sum is larger than <see cref="Decimal.MaxValue"/>.</exception>
         public static async Task<decimal> SumAsync(this IQueryable<decimal> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (decimal)await ExecuteAsync(source.Provider, FinalExpression(source, sumDecimalMethodInfo.Value), cancellationToken);
+            return (decimal)await ExecuteAsync(source.Provider, FinalExpression(source, sumDecimalMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -186,7 +186,7 @@ namespace ElasticLinq.Async
         /// <exception cref="OverflowException">The sum is larger than <see cref="Decimal.MaxValue"/>.</exception>
         public static async Task<decimal?> SumAsync(this IQueryable<decimal?> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (decimal?)await ExecuteAsync(source.Provider, FinalExpression(source, sumDecimalNullableMethodInfo.Value), cancellationToken);
+            return (decimal?)await ExecuteAsync(source.Provider, FinalExpression(source, sumDecimalNullableMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -204,7 +204,7 @@ namespace ElasticLinq.Async
         /// <exception cref="OverflowException">The sum is larger than <see cref="Int32.MaxValue"/>.</exception>
         public static async Task<int> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (int)await ExecuteAsync(source.Provider, FinalExpression(source, sumIntSelectorMethodInfo.Value, selector), cancellationToken);
+            return (int)await ExecuteAsync(source.Provider, FinalExpression(source, sumIntSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace ElasticLinq.Async
         /// <exception cref="OverflowException">The sum is larger than <see cref="Int32.MaxValue"/>.</exception>
         public static async Task<int?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (int?)await ExecuteAsync(source.Provider, FinalExpression(source, sumIntNullableSelectorMethodInfo.Value, selector), cancellationToken);
+            return (int?)await ExecuteAsync(source.Provider, FinalExpression(source, sumIntNullableSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -240,7 +240,7 @@ namespace ElasticLinq.Async
         /// <exception cref="OverflowException">The sum is larger than <see cref="Int64.MaxValue"/>.</exception>
         public static async Task<long> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (long)await ExecuteAsync(source.Provider, FinalExpression(source, sumLongSelectorMethodInfo.Value, selector), cancellationToken);
+            return (long)await ExecuteAsync(source.Provider, FinalExpression(source, sumLongSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -258,7 +258,7 @@ namespace ElasticLinq.Async
         /// <exception cref="OverflowException">The sum is larger than <see cref="Int64.MaxValue"/>.</exception>
         public static async Task<long?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (long?)await ExecuteAsync(source.Provider, FinalExpression(source, sumLongNullableSelectorMethodInfo.Value, selector), cancellationToken);
+            return (long?)await ExecuteAsync(source.Provider, FinalExpression(source, sumLongNullableSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -275,7 +275,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<float> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (float)await ExecuteAsync(source.Provider, FinalExpression(source, sumFloatSelectorMethodInfo.Value, selector), cancellationToken);
+            return (float)await ExecuteAsync(source.Provider, FinalExpression(source, sumFloatSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -292,7 +292,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<float?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (float?)await ExecuteAsync(source.Provider, FinalExpression(source, sumFloatNullableSelectorMethodInfo.Value, selector), cancellationToken);
+            return (float?)await ExecuteAsync(source.Provider, FinalExpression(source, sumFloatNullableSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -309,7 +309,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<double> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, sumDoubleSelectorMethodInfo.Value, selector), cancellationToken);
+            return (double)await ExecuteAsync(source.Provider, FinalExpression(source, sumDoubleSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -326,7 +326,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<double?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (double?)await ExecuteAsync(source.Provider, FinalExpression(source, sumDoubleNullableSelectorMethodInfo.Value, selector), cancellationToken);
+            return (double?)await ExecuteAsync(source.Provider, FinalExpression(source, sumDoubleNullableSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -344,7 +344,7 @@ namespace ElasticLinq.Async
         /// <exception cref="OverflowException">The sum is larger than <see cref="Decimal.MaxValue"/>.</exception>
         public static async Task<decimal> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (decimal)await ExecuteAsync(source.Provider, FinalExpression(source, sumDecimalSelectorMethodInfo.Value, selector), cancellationToken);
+            return (decimal)await ExecuteAsync(source.Provider, FinalExpression(source, sumDecimalSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -362,7 +362,7 @@ namespace ElasticLinq.Async
         /// <exception cref="OverflowException">The sum is larger than <see cref="Decimal.MaxValue"/>.</exception>
         public static async Task<decimal?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal?>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (decimal?)await ExecuteAsync(source.Provider, FinalExpression(source, sumDecimalNullableSelectorMethodInfo.Value, selector), cancellationToken);
+            return (decimal?)await ExecuteAsync(source.Provider, FinalExpression(source, sumDecimalNullableSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/Source/ElasticLINQ/Async/AsyncQueryable.cs
+++ b/Source/ElasticLINQ/Async/AsyncQueryable.cs
@@ -38,7 +38,7 @@ namespace ElasticLinq.Async
         /// <exception cref="OverflowException">The number of elements in <paramref name="source"/> is larger than <see cref="Int32.MaxValue"/>.</exception>
         public static async Task<int> CountAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (int)await ExecuteAsync(source.Provider, FinalExpression(source, countMethodInfo.Value), cancellationToken);
+            return (int)await ExecuteAsync(source.Provider, FinalExpression(source, countMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace ElasticLinq.Async
         /// <exception cref="OverflowException">The number of elements in <paramref name="source"/> is larger than <see cref="Int32.MaxValue"/>.</exception>
         public static async Task<int> CountAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (int)await ExecuteAsync(source.Provider, FinalExpression(source, countPredicateMethodInfo.Value, predicate), cancellationToken);
+            return (int)await ExecuteAsync(source.Provider, FinalExpression(source, countPredicateMethodInfo.Value, predicate), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace ElasticLinq.Async
         /// <exception cref="OverflowException">The number of elements exceeds <see cref="Int64.MaxValue"/>.</exception>
         public static async Task<long> LongCountAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (long)await ExecuteAsync(source.Provider, FinalExpression(source, longCountMethodInfo.Value), cancellationToken);
+            return (long)await ExecuteAsync(source.Provider, FinalExpression(source, longCountMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace ElasticLinq.Async
         /// <exception cref="OverflowException">The number of matching elements exceeds <see cref="Int64.MaxValue"/>.</exception>
         public static async Task<long> LongCountAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (long)await ExecuteAsync(source.Provider, FinalExpression(source, longCountPredicateMethodInfo.Value, predicate), cancellationToken);
+            return (long)await ExecuteAsync(source.Provider, FinalExpression(source, longCountPredicateMethodInfo.Value, predicate), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> is null.</exception>
         public static async Task<TSource> MinAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, minMethodInfo.Value), cancellationToken);
+            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, minMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<TResult> MinAsync<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (TResult)await ExecuteAsync(source.Provider, FinalExpression<TSource, TResult>(source, minSelectorMethodInfo.Value, selector), cancellationToken);
+            return (TResult)await ExecuteAsync(source.Provider, FinalExpression<TSource, TResult>(source, minSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> is null.</exception>
         public static async Task<TSource> MaxAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, maxMethodInfo.Value), cancellationToken);
+            return (TSource)await ExecuteAsync(source.Provider, FinalExpression(source, maxMethodInfo.Value), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace ElasticLinq.Async
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<TResult> MaxAsync<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (TResult)await ExecuteAsync(source.Provider, FinalExpression<TSource, TResult>(source, maxSelectorMethodInfo.Value, selector), cancellationToken);
+            return (TResult)await ExecuteAsync(source.Provider, FinalExpression<TSource, TResult>(source, maxSelectorMethodInfo.Value, selector), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -173,7 +173,7 @@ namespace ElasticLinq.Async
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         public static async Task<List<TSource>> ToListAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return ((IEnumerable<TSource>)await ExecuteAsync(source.Provider, source.Expression, cancellationToken)).ToList();
+            return ((IEnumerable<TSource>)await ExecuteAsync(source.Provider, source.Expression, cancellationToken).ConfigureAwait(false)).ToList();
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace ElasticLinq.Async
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         public static async Task<TSource[]> ToArrayAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return ((IEnumerable<TSource>)await ExecuteAsync(source.Provider, source.Expression, cancellationToken)).ToArray();
+            return ((IEnumerable<TSource>)await ExecuteAsync(source.Provider, source.Expression, cancellationToken).ConfigureAwait(false)).ToArray();
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace ElasticLinq.Async
         /// <paramref name="keySelector" /> produces duplicate keys for two elements.</exception>
         public static async Task<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(this IQueryable<TSource> source, Func<TSource, TKey> keySelector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return ((IEnumerable<TSource>)await ExecuteAsync(source.Provider, source.Expression, cancellationToken)).ToDictionary(keySelector);
+            return ((IEnumerable<TSource>)await ExecuteAsync(source.Provider, source.Expression, cancellationToken).ConfigureAwait(false)).ToDictionary(keySelector);
         }
 
         /// <summary>
@@ -229,7 +229,7 @@ namespace ElasticLinq.Async
         /// <paramref name="keySelector" /> produces duplicate keys for two elements.</exception>
         public static async Task<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(this IQueryable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return ((IEnumerable<TSource>)await ExecuteAsync(source.Provider, source.Expression, cancellationToken)).ToDictionary(keySelector, elementSelector);
+            return ((IEnumerable<TSource>)await ExecuteAsync(source.Provider, source.Expression, cancellationToken).ConfigureAwait(false)).ToDictionary(keySelector, elementSelector);
         }
 
         static Lazy<MethodInfo> QueryableMethodByArgs(string name, int parameterCount, Type secondParameterType = null)

--- a/Source/ElasticLINQ/Async/AsyncQueryable.cs
+++ b/Source/ElasticLINQ/Async/AsyncQueryable.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace ElasticLinq.Async
 {
     /// <summary>
-    /// Provides a set of static methods for querying data structures that implement <see cref="T:System.Linq.IQueryable`1"/> in an asynchronous manner.
+    /// Provides a set of static methods for querying data structures that implement <see cref="IQueryable{T}"/> in an asynchronous manner.
     /// </summary>
     public static partial class AsyncQueryable
     {
@@ -30,12 +30,12 @@ namespace ElasticLinq.Async
         /// <returns>
         /// A task that returns the number of elements in the input sequence.
         /// </returns>
-        /// <param name="source">The <see cref="T:System.Linq.IQueryable`1"/> that contains the elements to be counted.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="source">The <see cref="IQueryable{T}"/> that contains the elements to be counted.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The number of elements in <paramref name="source"/> is larger than <see cref="F:System.Int32.MaxValue"/>.</exception>
+        /// <exception cref="OverflowException">The number of elements in <paramref name="source"/> is larger than <see cref="Int32.MaxValue"/>.</exception>
         public static async Task<int> CountAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (int)await ExecuteAsync(source.Provider, FinalExpression(source, countMethodInfo.Value), cancellationToken);
@@ -47,63 +47,63 @@ namespace ElasticLinq.Async
         /// <returns>
         /// A task that returns the number of elements in the sequence that satisfies the condition in the predicate function.
         /// </returns>
-        /// <param name="source">An <see cref="T:System.Linq.IQueryable`1"/> that contains the elements to be counted.</param>
+        /// <param name="source">An <see cref="IQueryable{T}"/> that contains the elements to be counted.</param>
         /// <param name="predicate">A function to test each element for a condition.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The number of elements in <paramref name="source"/> is larger than <see cref="F:System.Int32.MaxValue"/>.</exception>
+        /// <exception cref="OverflowException">The number of elements in <paramref name="source"/> is larger than <see cref="Int32.MaxValue"/>.</exception>
         public static async Task<int> CountAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (int)await ExecuteAsync(source.Provider, FinalExpression(source, countPredicateMethodInfo.Value, predicate), cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously returns an <see cref="T:System.Int64"/> that represents the total number of elements in a sequence.
+        /// Asynchronously returns an <see cref="Int64"/> that represents the total number of elements in a sequence.
         /// </summary>
         /// <returns>
         /// A task that returns the number of elements in <paramref name="source"/>.
         /// </returns>
-        /// <param name="source">An <see cref="T:System.Linq.IQueryable`1"/> that contains the elements to be counted.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="source">An <see cref="IQueryable{T}"/> that contains the elements to be counted.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The number of elements exceeds <see cref="F:System.Int64.MaxValue"/>.</exception>
+        /// <exception cref="OverflowException">The number of elements exceeds <see cref="Int64.MaxValue"/>.</exception>
         public static async Task<long> LongCountAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (long)await ExecuteAsync(source.Provider, FinalExpression(source, longCountMethodInfo.Value), cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously returns an <see cref="T:System.Int64"/> that represents the number of elements in a sequence that satisfy a condition.
+        /// Asynchronously returns an <see cref="Int64"/> that represents the number of elements in a sequence that satisfy a condition.
         /// </summary>
         /// <returns>
         /// A task that returns the number of elements in <paramref name="source"/> that satisfy the condition in the predicate function.
         /// </returns>
-        /// <param name="source">An <see cref="T:System.Linq.IQueryable`1"/> that contains the elements to be counted.</param>
+        /// <param name="source">An <see cref="IQueryable{T}"/> that contains the elements to be counted.</param>
         /// <param name="predicate">A function to test each element for a condition.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The number of matching elements exceeds <see cref="F:System.Int64.MaxValue"/>.</exception>
+        /// <exception cref="OverflowException">The number of matching elements exceeds <see cref="Int64.MaxValue"/>.</exception>
         public static async Task<long> LongCountAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default(CancellationToken))
         {
             return (long)await ExecuteAsync(source.Provider, FinalExpression(source, longCountPredicateMethodInfo.Value, predicate), cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously returns the minimum value of a generic <see cref="T:System.Linq.IQueryable`1"/>.
+        /// Asynchronously returns the minimum value of a generic <see cref="IQueryable{T}"/>.
         /// </summary>
         /// <returns>
         /// A task that returns the minimum value in the sequence.
         /// </returns>
         /// <param name="source">A sequence of values to determine the minimum of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
         public static async Task<TSource> MinAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -111,17 +111,17 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Invokes a projection function on each element of a generic <see cref="T:System.Linq.IQueryable`1"/> and returns the minimum resulting value.
+        /// Invokes a projection function on each element of a generic <see cref="IQueryable{T}"/> and returns the minimum resulting value.
         /// </summary>
         /// <returns>
         /// A task that returns the minimum value in the sequence.
         /// </returns>
         /// <param name="source">A sequence of values to determine the minimum of.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <typeparam name="TResult">The type of the value returned by the function represented by <paramref name="selector"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<TResult> MinAsync<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -129,15 +129,15 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Asynchronously returns the maximum value in a generic <see cref="T:System.Linq.IQueryable`1"/>.
+        /// Asynchronously returns the maximum value in a generic <see cref="IQueryable{T}"/>.
         /// </summary>
         /// <returns>
         /// A task that returns the maximum value in the sequence.
         /// </returns>
         /// <param name="source">A sequence of values to determine the maximum of.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.</exception>
         public static async Task<TSource> MaxAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -145,17 +145,17 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Invokes a projection function on each element of a generic <see cref="T:System.Linq.IQueryable`1"/> and returns the maximum resulting value.
+        /// Invokes a projection function on each element of a generic <see cref="IQueryable{T}"/> and returns the maximum resulting value.
         /// </summary>
         /// <returns>
         /// A task that returns the maximum value in the sequence.
         /// </returns>
         /// <param name="source">A sequence of values to determine the maximum of.</param>
         /// <param name="selector">A projection function to apply to each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <typeparam name="TResult">The type of the value returned by the function represented by <paramref name="selector"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is null.</exception>
         public static async Task<TResult> MaxAsync<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -163,13 +163,13 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Creates a <see cref="T:System.Collection.List`1"/> from an <see cref="T:System.Linq.IQueryable`1"/> that is executed asyncronously.
+        /// Creates a <see cref="List{T}"/> from an <see cref="IQueryable{T}"/> that is executed asyncronously.
         /// </summary>
         /// <returns>
         /// A task that returns the newly created list.
         /// </returns>
         /// <param name="source">A sequence of values to create a list from.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         public static async Task<List<TSource>> ToListAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -177,13 +177,13 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Creates an array from an <see cref="T:System.Linq.IQueryable`1"/> that is executed asyncronously.
+        /// Creates an array from an <see cref="IQueryable{T}"/> that is executed asyncronously.
         /// </summary>
         /// <returns>
         /// A task that returns the newly created array.
         /// </returns>
         /// <param name="source">A sequence of values to create an array from.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         public static async Task<TSource[]> ToArrayAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -191,19 +191,19 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Creates a <see cref="T:System.Collections.Generic.Dictionary`2" /> from an <see cref="T:System.Collections.Generic.IEnumerable`1" /> according to a specified key selector function.
+        /// Creates a <see cref="Dictionary{TKey, TValue}" /> from an <see cref="IEnumerable{T}" /> according to a specified key selector function.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.Collections.Generic.Dictionary`2" /> that contains keys and values.
+        /// A <see cref="Dictionary{TKey, TValue}" /> that contains keys and values.
         /// </returns>
-        /// <param name="source">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> to create a <see cref="T:System.Collections.Generic.Dictionary`2" /> from.</param>
+        /// <param name="source">An <see cref="IEnumerable{T}" /> to create a <see cref="Dictionary{TKey, TValue}" /> from.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector" />.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source" /> or <paramref name="keySelector" /> is null.-or-<paramref name="keySelector" /> produces a key that is null.</exception>
-        /// <exception cref="T:System.ArgumentException">
+        /// <exception cref="ArgumentException">
         /// <paramref name="keySelector" /> produces duplicate keys for two elements.</exception>
         public static async Task<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(this IQueryable<TSource> source, Func<TSource, TKey> keySelector, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -211,21 +211,21 @@ namespace ElasticLinq.Async
         }
 
         /// <summary>
-        /// Creates a <see cref="T:System.Collections.Generic.Dictionary`2" /> from an <see cref="T:System.Collections.Generic.IEnumerable`1" /> according to specified key selector and element selector functions.
+        /// Creates a <see cref="Dictionary{TKey, TValue}" /> from an <see cref="IEnumerable{T}" /> according to specified key selector and element selector functions.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.Collections.Generic.Dictionary`2" /> that contains values of type <typeparamref name="TElement" /> selected from the input sequence.
+        /// A <see cref="Dictionary{TKey, TValue}" /> that contains values of type <typeparamref name="TElement" /> selected from the input sequence.
         /// </returns>
-        /// <param name="source">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> to create a <see cref="T:System.Collections.Generic.Dictionary`2" /> from.</param>
+        /// <param name="source">An <see cref="IEnumerable{T}" /> to create a <see cref="Dictionary{TKey, TValue}" /> from.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
-        /// <param name="cancellationToken">The optional <see cref="T:System.Threading.CancellationToken"/> which can be used to cancel this task.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> which can be used to cancel this task.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector" />.</typeparam>
         /// <typeparam name="TElement">The type of the value returned by <paramref name="elementSelector" />.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="source" /> or <paramref name="keySelector" /> or <paramref name="elementSelector" /> is null.-or-<paramref name="keySelector" /> produces a key that is null.</exception>
-        /// <exception cref="T:System.ArgumentException">
+        /// <exception cref="ArgumentException">
         /// <paramref name="keySelector" /> produces duplicate keys for two elements.</exception>
         public static async Task<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(this IQueryable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/Source/ElasticLINQ/Async/IAsyncQueryExecutor.cs
+++ b/Source/ElasticLINQ/Async/IAsyncQueryExecutor.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace ElasticLinq.Async
 {
     /// <summary>
-    /// Defines methods to asyncronously execute queries that are described by an <see cref="T:System.Linq.IQueryable" /> object.
+    /// Defines methods to asyncronously execute queries that are described by an <see cref="System.Linq.IQueryable" /> object.
     /// </summary>
     public interface IAsyncQueryExecutor
     {

--- a/Source/ElasticLINQ/ElasticConnection.cs
+++ b/Source/ElasticLINQ/ElasticConnection.cs
@@ -111,9 +111,9 @@ namespace ElasticLinq
             {
                 try
                 {
-                    using (var response = await SendRequestAsync(requestMessage, token, log))
+                    using (var response = await SendRequestAsync(requestMessage, token, log).ConfigureAwait(false))
                     {
-                        using (var responseStream = await response.Content.ReadAsStreamAsync())
+                        using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
                             return ParseResponse(responseStream, log);
                     }
                 }
@@ -155,7 +155,7 @@ namespace ElasticLinq
         private async Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage requestMessage, CancellationToken token, ILog log)
         {
             var stopwatch = Stopwatch.StartNew();
-            var response = await HttpClient.SendAsync(requestMessage, token);
+            var response = await HttpClient.SendAsync(requestMessage, token).ConfigureAwait(false);
             stopwatch.Stop();
 
             log.Debug(null, null, "Response: {0} {1} (in {2}ms)", (int)response.StatusCode, response.StatusCode, stopwatch.ElapsedMilliseconds);

--- a/Source/ElasticLINQ/ElasticQueryExtensions.cs
+++ b/Source/ElasticLINQ/ElasticQueryExtensions.cs
@@ -21,12 +21,12 @@ namespace ElasticLinq
         /// Queries an Elasticsearch index based on a query string.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Linq.IQueryable`1"/> that contains elements from the input sequence that satisfy the condition specified by <paramref name="query"/>.
+        /// An <see cref="IQueryable{T}"/> that contains elements from the input sequence that satisfy the condition specified by <paramref name="query"/>.
         /// </returns>
-        /// <param name="source">An <see cref="T:System.Linq.IQueryable`1"/> to query.</param>
+        /// <param name="source">An <see cref="IQueryable{T}"/> to query.</param>
         /// <param name="query">A query string to test each element for.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="source"/> or <paramref name="query"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="query"/> is null.</exception>
         public static IQueryable<TSource> QueryString<TSource>(this IQueryable<TSource> source, string query)
         {
             Argument.EnsureNotNull(nameof(query), query);
@@ -37,13 +37,13 @@ namespace ElasticLinq
         /// Queries an Elasticsearch index based on a query string for specific field partterns.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Linq.IQueryable`1"/> that contains elements from the input sequence that satisfy the condition specified by <paramref name="query"/>.
+        /// An <see cref="IQueryable{T}"/> that contains elements from the input sequence that satisfy the condition specified by <paramref name="query"/>.
         /// </returns>
-        /// <param name="source">An <see cref="T:System.Linq.IQueryable`1"/> to query.</param>
+        /// <param name="source">An <see cref="IQueryable{T}"/> to query.</param>
         /// <param name="query">A query string to test each element for.</param>
         /// <param name="fields">A list of field name patterns to search.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="source"/>, <paramref name="query"/> or <paramref name="fields"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/>, <paramref name="query"/> or <paramref name="fields"/> is null.</exception>
         public static IQueryable<TSource> QueryString<TSource>(this IQueryable<TSource> source, string query, string[] fields)
         {
             Argument.EnsureNotNull(nameof(query), query);
@@ -55,10 +55,10 @@ namespace ElasticLinq
         /// Sorts the elements of a sequence in ascending order by their Elasticsearch score.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Linq.IOrderedQueryable`1"/> whose elements are sorted according to score.
+        /// An <see cref="IOrderedQueryable{T}"/> whose elements are sorted according to score.
         /// </returns>
         /// <param name="source">A sequence of values to order.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="source"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static IOrderedQueryable<TSource> OrderByScore<TSource>(this IQueryable<TSource> source)
         {
             return (IOrderedQueryable<TSource>)CreateQueryMethodCall(source, orderByScoreMethodInfo);
@@ -68,10 +68,10 @@ namespace ElasticLinq
         /// Sorts the elements of a sequence in descending order by their Elasticsearch score.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Linq.IOrderedQueryable`1"/> whose elements are sorted according to score.
+        /// An <see cref="IOrderedQueryable{T}"/> whose elements are sorted according to score.
         /// </returns>
         /// <param name="source">A sequence of values to order.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="source"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static IOrderedQueryable<TSource> OrderByScoreDescending<TSource>(this IQueryable<TSource> source)
         {
             return (IOrderedQueryable<TSource>)CreateQueryMethodCall(source, orderByScoreDescendingMethodInfo);
@@ -81,10 +81,10 @@ namespace ElasticLinq
         /// Performs a subsequent ordering of the elements in a sequence in ascending order by their Elasticsearch score.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Linq.IOrderedQueryable`1"/> whose elements are sorted according to score.
+        /// An <see cref="IOrderedQueryable{T}"/> whose elements are sorted according to score.
         /// </returns>
         /// <param name="source">A sequence of values to order.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="source"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static IOrderedQueryable<TSource> ThenByScore<TSource>(this IOrderedQueryable<TSource> source)
         {
             return (IOrderedQueryable<TSource>)CreateQueryMethodCall(source, thenByScoreMethodInfo);
@@ -94,10 +94,10 @@ namespace ElasticLinq
         /// Performs a subsequent ordering of the elements in a sequence in descending order by their Elasticsearch score.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Linq.IOrderedQueryable`1"/> whose elements are sorted according to score.
+        /// An <see cref="IOrderedQueryable{T}"/> whose elements are sorted according to score.
         /// </returns>
         /// <param name="source">A sequence of values to order.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="source"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static IOrderedQueryable<TSource> ThenByScoreDescending<TSource>(this IOrderedQueryable<TSource> source)
         {
             return (IOrderedQueryable<TSource>)CreateQueryMethodCall(source, thenByScoreDescendingMethodInfo);
@@ -107,11 +107,11 @@ namespace ElasticLinq
         /// Specifies a minimum Elasticsearch score.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Linq.IQueryable`1"/> whose elements have a score greater or equal to the score specified.
+        /// An <see cref="IQueryable{T}"/> whose elements have a score greater or equal to the score specified.
         /// </returns>
         /// <param name="source">A sequence of values to apply a minimum score to.</param>
         /// <param name="score">The minimal acceptable score for results.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="source"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static IQueryable<TSource> MinScore<TSource>(this IQueryable<TSource> source, double score)
         {
             return CreateQueryMethodCall(source, minimumScoreMethodInfo, Expression.Constant(score));
@@ -121,12 +121,12 @@ namespace ElasticLinq
         /// Specifies highlighting for search results.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Linq.IQueryable`1"/> with elements containing hightlights as specified.
+        /// An <see cref="IQueryable{T}"/> with elements containing hightlights as specified.
         /// </returns>
         /// <param name="source">A sequence of values to order.</param>
         /// <param name="predicate">A function to test each element for a condition.</param>
         /// <param name="highlight">Highlight specification to apply to search.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         public static IQueryable<TSource> Highlight<TSource, TKey>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> predicate, Highlight highlight = null)
         {
             Argument.EnsureNotNull(nameof(source), source);
@@ -137,7 +137,7 @@ namespace ElasticLinq
         /// <summary>
         /// Return information about a <see cref="IElasticQuery{T}"/> including the JSON that would be submitted to Elasticsearch.
         /// </summary>
-        /// <param name="source">An <see cref="T:System.Linq.IQueryable{T}"/> to query.</param>
+        /// <param name="source">An <see cref="IQueryable{T}"/> to query.</param>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <returns>QueryInfo including the Uri and Elasticsearch DSL JSON representing this query.</returns>
         /// <exception cref="ArgumentException"><paramref name="source"/> is not of type <see cref="IElasticQuery{T}"/>.</exception>

--- a/Source/ElasticLINQ/ElasticQueryProvider.cs
+++ b/Source/ElasticLINQ/ElasticQueryProvider.cs
@@ -100,7 +100,7 @@ namespace ElasticLinq
         /// <inheritdoc/>
         public async Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (TResult)await ExecuteAsync(expression, cancellationToken);
+            return (TResult)await ExecuteAsync(expression, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -121,7 +121,7 @@ namespace ElasticLinq
                 }
                 else
                 {
-                    response = await requestProcessor.SearchAsync(translation.SearchRequest, cancellationToken);
+                    response = await requestProcessor.SearchAsync(translation.SearchRequest, cancellationToken).ConfigureAwait(false);
                     if (response == null)
                         throw new InvalidOperationException("No HTTP response received.");
                 }

--- a/Source/ElasticLINQ/Retry/RetryPolicy.cs
+++ b/Source/ElasticLINQ/Retry/RetryPolicy.cs
@@ -55,7 +55,7 @@ namespace ElasticLinq.Retry
                 var operationResult = default(TOperation);
                 try
                 {
-                    operationResult = await operationFunc(cancellationToken);
+                    operationResult = await operationFunc(cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -91,7 +91,7 @@ namespace ElasticLinq.Retry
 
                 Log.Info(operationException, loggerInfo, "The operation failed (attempt #{0}) and will be retried.", attempt);
 
-                await Delay.For(retryDelay, cancellationToken);
+                await Delay.For(retryDelay, cancellationToken).ConfigureAwait(false);
                 retryDelay = retryDelay * 2;
             }
         }

--- a/Source/ElasticLINQ/Test/TestableElasticQueryProvider.cs
+++ b/Source/ElasticLINQ/Test/TestableElasticQueryProvider.cs
@@ -53,13 +53,13 @@ namespace ElasticLinq.Test
         /// <inheritdoc/>
         public async Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken = new CancellationToken())
         {
-            return (TResult)await ExecuteAsync(expression, cancellationToken);
+            return (TResult)await ExecuteAsync(expression, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
         public async Task<object> ExecuteAsync(Expression expression, CancellationToken cancellationToken = new CancellationToken())
         {
-            return await Task.Run(() => Execute(expression), cancellationToken);
+            return await Task.Run(() => Execute(expression), cancellationToken).ConfigureAwait(false);
         }
 
         class TestableElasticQueryRewriter : ExpressionVisitor


### PR DESCRIPTION
- Configure awaits with `ConfigureAwait(false)` everywhere to avoid capturing contexts
- Change `cref` xml documentation format for consistency/brevity