### PR TITLE
Force Content-Type to 'application/json' 

### DIFF
--- a/Source/ElasticLINQ/ElasticConnection.cs
+++ b/Source/ElasticLINQ/ElasticConnection.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -109,6 +110,7 @@ namespace ElasticLinq
 
             using (var requestMessage = new HttpRequestMessage(HttpMethod.Post, uri) {Content = new StringContent(body)})
             {
+                requestMessage.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
                 try
                 {
                     using (var response = await SendRequestAsync(requestMessage, token, log).ConfigureAwait(false))


### PR DESCRIPTION
(fails on ES 6.2.4 with the default Content-Type)

This is all I needed to do to get basic queries working against and ES 6.2.4 instance.
I get a few unit test failures with or without this change - not sure what's causing those.